### PR TITLE
Update coredns-down.tf

### DIFF
--- a/terraform/system/coredns-down.tf
+++ b/terraform/system/coredns-down.tf
@@ -14,35 +14,18 @@
 
 resource "google_monitoring_alert_policy" "coredns-down-alert" {
   display_name = "CoreDNS down (critical)"
-  combiner = "OR"
+  combiner     = "OR"
+
+  # This label allows the alert to show up in your "Managed" UI filter
+  user_labels = {
+    managed = "true"
+  }
+
   conditions {
     display_name = "CoreDNS is up"
-    condition_monitoring_query_language {
-      query = <<EOL
-      { t_0:
-          fetch k8s_container
-          | metric 'kubernetes.io/anthos/container/uptime'
-          | filter (resource.container_name =~ 'coredns')
-          | align mean_aligner()
-          | group_by 1m, [value_up_mean: mean(value.uptime)]
-          | every 1m
-          | group_by [resource.project_id, resource.location, resource.cluster_name],
-              [value_up_mean_aggregate: aggregate(value_up_mean)]
-      ; t_1:
-          fetch k8s_container::kubernetes.io/anthos/anthos_cluster_info
-          | filter (metric.anthos_distribution = 'baremetal')
-          | align mean_aligner()
-          | group_by [resource.project_id, resource.location, resource.cluster_name],
-              [value_anthos_cluster_info_aggregate:
-                 aggregate(value.anthos_cluster_info)]
-          | every 1m }
-      | join
-      | value [t_0.value_up_mean_aggregate]
-      | window 1m
-      | condition val() < 1
-        EOL
-      
-      duration = "0s"
+    condition_prometheus_query_language {
+      query    = "(max by (cluster, location, project_id) (label_replace(kubernetes_io:anthos_anthos_cluster_info{anthos_distribution=\"baremetal\", monitored_resource=\"k_container\"}, \"cluster\", \"$1\", \"cluster_name\", \"(.*)\"))) unless (avg by (cluster, location, project_id) (kubernetes_io:anthos_container_uptime{container_name=~\"coredns\", monitored_resource=\"k8s_container\"}))"
+      duration = "300s"
       trigger {
         count = 1
       }


### PR DESCRIPTION
## Description
This PR migrates the CoreDNS Down alert from MQL to PromQL within the Terraform configuration. 

. 

### Changes:
- **File:** `terraform/system/coredns-down.tf`
- **Migration:** Converted `condition_monitoring_query_language` (MQL) to `condition_prometheus_query_language` (PromQL).
- **Metadata:** Added `user_labels = { managed = "true" }` to ensure the alert appears in the managed observability dashboard filter.

