### PR TITLE
fix: correct monitored_resource type in CoreDNS down PromQL query

### DIFF
--- a/alerts/system/coredns-down.yaml
+++ b/alerts/system/coredns-down.yaml
@@ -16,6 +16,6 @@ combiner: OR
 conditions:
 - conditionPrometheusQueryLanguage:
     duration: 300s
-    query: '(max by (cluster, location, project_id) (label_replace(kubernetes_io:anthos_anthos_cluster_info{anthos_distribution="baremetal", monitored_resource="k8_container"}, "cluster", "$1", "cluster_name", "(.*)"))) unless (avg by (cluster, location, project_id) (kubernetes_io:anthos_container_uptime{container_name=~"coredns", monitored_resource="k8s_container"}))'
+    query: '(max by (cluster, location, project_id) (label_replace(kubernetes_io:anthos_anthos_cluster_info{anthos_distribution="baremetal", monitored_resource="k8s_container"}, "cluster", "$1", "cluster_name", "(.*)"))) unless (avg by (cluster, location, project_id) (kubernetes_io:anthos_container_uptime{container_name=~"coredns", monitored_resource="k8s_container"}))'
   displayName: CoreDNS is up
 displayName: CoreDNS down (critical)

--- a/terraform/system/coredns-down.tf
+++ b/terraform/system/coredns-down.tf
@@ -24,7 +24,7 @@ resource "google_monitoring_alert_policy" "coredns-down-alert" {
   conditions {
     display_name = "CoreDNS is up"
     condition_prometheus_query_language {
-      query    = "(max by (cluster, location, project_id) (label_replace(kubernetes_io:anthos_anthos_cluster_info{anthos_distribution=\"baremetal\", monitored_resource=\"k8_container\"}, \"cluster\", \"$1\", \"cluster_name\", \"(.*)\"))) unless (avg by (cluster, location, project_id) (kubernetes_io:anthos_container_uptime{container_name=~\"coredns\", monitored_resource=\"k8s_container\"}))"
+      query    = "(max by (cluster, location, project_id) (label_replace(kubernetes_io:anthos_anthos_cluster_info{anthos_distribution=\"baremetal\", monitored_resource=\"k8s_container\"}, \"cluster\", \"$1\", \"cluster_name\", \"(.*)\"))) unless (avg by (cluster, location, project_id) (kubernetes_io:anthos_container_uptime{container_name=~\"coredns\", monitored_resource=\"k8s_container\"}))"
       duration = "300s"
       trigger {
         count = 1


### PR DESCRIPTION
## Description
This PR fixes a typo in the CoreDNS Down alert PromQL query that was causing deployment failures.

### The Issue:
The previous query used `monitored_resource="k_container"`. According to the Google Cloud Monitoring API, `k8_container` is not a valid resource type for the `anthos_cluster_info` metric, resulting in the following error during deployment:
`INVALID_ARGUMENT: metric type kubernetes.io/anthos/anthos_cluster_info is not queryable for monitored resource k8_container`

### The Fix:
Updated the monitored resource name to the correct value: **`k8s_container`**.

### Files Updated:
1.  `alerts/system/coredns-down.yaml`
2.  `terraform/system/coredns-down.tf` (Ensuring Terraform state remains consistent with manual deployment)

### Validation:
- Manually verified via `gcloud alpha monitoring policies create` in Cloud Shell.
- The policy is now successfully created in the GCP Console with the corrected PromQL logic.