### PR TITLE
feat: migrate Control Plane observability alerts from MQL to PromQL

### DIFF
--- a/alerts/control-plane/api-server-error-ratio-5-percent.yaml
+++ b/alerts/control-plane/api-server-error-ratio-5-percent.yaml
@@ -22,5 +22,5 @@ conditions:
       sum by(project_id, location, cluster_name) (increase(kubernetes_io:anthos_apiserver_aggregated_request_total{container_name=~"kube-apiserver"}[5m]))
       * on(project_id, location, cluster_name) group_left() (kubernetes_io:anthos_anthos_cluster_info{anthos_distribution="baremetal", monitored_resource="k8s_container"}))
       > 0.05
-  displayName: 'API server error count ratio: 500s error-response counts / all response counts -'
+  displayName: 'API server error count ratio: 500s error-response counts / all response counts'
 displayName: API server error count ratio exceeds 5 percent 

--- a/alerts/control-plane/api-server-error-ratio-5-percent.yaml
+++ b/alerts/control-plane/api-server-error-ratio-5-percent.yaml
@@ -14,50 +14,13 @@
 
 combiner: OR
 conditions:
-- conditionMonitoringQueryLanguage:
+- conditionPrometheusQueryLanguage:
     duration: 600s
     query: |-
-      { t_0:
-          { t_0:
-              fetch k8s_container
-              | metric 'kubernetes.io/anthos/apiserver_aggregated_request_total'
-              | filter
-                  (resource.container_name =~ 'kube-apiserver')
-                  && (metric.code =~ '^(?:5..)$')
-              | align delta(5m)
-              | every 5m
-              | group_by
-                  [resource.project_id, resource.location, resource.cluster_name],
-                  [value_apiserver_aggregated_request_total_aggregate:
-                     aggregate(value.apiserver_aggregated_request_total)]
-          ; t_1:
-              fetch k8s_container
-              | metric 'kubernetes.io/anthos/apiserver_aggregated_request_total'
-              | filter (resource.container_name =~ 'kube-apiserver')
-              | align delta(5m)
-              | every 5m
-              | group_by
-                  [resource.project_id, resource.location, resource.cluster_name],
-                  [value_apiserver_aggregated_request_total_aggregate:
-                     aggregate(value.apiserver_aggregated_request_total)] }
-          | join
-          | value
-              [v_0:
-                 div(t_0.value_apiserver_aggregated_request_total_aggregate,
-                   t_1.value_apiserver_aggregated_request_total_aggregate)]
-      ; t_2:
-          fetch k8s_container::kubernetes.io/anthos/anthos_cluster_info
-          | filter (metric.anthos_distribution = 'baremetal')
-          | align mean_aligner()
-          | group_by [resource.project_id, resource.location, resource.cluster_name],
-              [value_anthos_cluster_info_aggregate:
-                 aggregate(value.anthos_cluster_info)]
-          | every 5m }
-      | join
-      | value [t_0.v_0]
-      | window 5m
-      | condition t_0.v_0 > 0.05 '1'
-    trigger:
-      count: 1
-  displayName: 'API server error count ratio: 500s error-response counts / all response counts'
-displayName: API server error count ratio exceeds 5 percent
+      (sum by(project_id, location, cluster_name) (increase(kubernetes_io:anthos_apiserver_aggregated_request_total{container_name=~"kube-apiserver", code=~"5.."}[5m]))
+      /
+      sum by(project_id, location, cluster_name) (increase(kubernetes_io:anthos_apiserver_aggregated_request_total{container_name=~"kube-apiserver"}[5m]))
+      * on(project_id, location, cluster_name) group_left() (kubernetes_io:anthos_anthos_cluster_info{anthos_distribution="baremetal", monitored_resource="k8s_container"}))
+      > 0.05
+  displayName: 'API server error count ratio: 500s error-response counts / all response counts -'
+displayName: API server error count ratio exceeds 5 percent 

--- a/alerts/control-plane/apiserver-down.yaml
+++ b/alerts/control-plane/apiserver-down.yaml
@@ -14,31 +14,9 @@
 
 combiner: OR
 conditions:
-- conditionMonitoringQueryLanguage:
-    duration: 0s
+- conditionPrometheusQueryLanguage:
+    duration: 300s
     query: |-
-      { t_0:
-          fetch k8s_container
-          | metric 'kubernetes.io/anthos/container/uptime'
-          | filter (resource.container_name =~ 'kube-apiserver')
-          | align mean_aligner()
-          | group_by 1m, [value_up_mean: mean(value.uptime)]
-          | every 1m
-          | group_by [resource.project_id, resource.location, resource.cluster_name],
-              [value_up_mean_aggregate: aggregate(value_up_mean)]
-      ; t_1:
-          fetch k8s_container::kubernetes.io/anthos/anthos_cluster_info
-          | filter (metric.anthos_distribution = 'baremetal')
-          | align mean_aligner()
-          | group_by [resource.project_id, resource.location, resource.cluster_name],
-              [value_anthos_cluster_info_aggregate:
-                 aggregate(value.anthos_cluster_info)]
-          | every 1m }
-      | join
-      | value [t_0.value_up_mean_aggregate]
-      | window 1m
-      | absent_for 300s
-    trigger:
-      count: 1
+      kubernetes_io:anthos_anthos_cluster_info{monitored_resource="k8s_container", anthos_distribution="baremetal"} unless on(cluster_name, location, project_id) kubernetes_io:anthos_container_uptime{monitored_resource="k8s_container", container_name=~"kube-apiserver"}
   displayName: API server is up
 displayName: API server down (critical)

--- a/alerts/control-plane/controller-manager-down.yaml
+++ b/alerts/control-plane/controller-manager-down.yaml
@@ -14,31 +14,9 @@
 
 combiner: OR
 conditions:
-- conditionMonitoringQueryLanguage:
-    duration: 600s
+- conditionPrometheusQueryLanguage:
+    duration: 300s
     query: |-
-      { t_0:
-          fetch k8s_container
-          | metric 'kubernetes.io/anthos/container/uptime'
-          | filter (resource.container_name =~ 'kube-controller-manager')
-          | align mean_aligner()
-          | group_by 1m, [value_up_mean: mean(value.uptime)]
-          | every 1m
-          | group_by [resource.project_id, resource.location, resource.cluster_name],
-              [value_up_mean_aggregate: aggregate(value_up_mean)]
-      ; t_1:
-          fetch k8s_container::kubernetes.io/anthos/anthos_cluster_info
-          | filter (metric.anthos_distribution = 'baremetal')
-          | align mean_aligner()
-          | group_by [resource.project_id, resource.location, resource.cluster_name],
-              [value_anthos_cluster_info_aggregate:
-                 aggregate(value.anthos_cluster_info)]
-          | every 1m }
-      | join
-      | value [t_0.value_up_mean_aggregate]
-      | window 1m
-      | absent_for 300s
-    trigger:
-      count: 1
-  displayName: Controller manager is up
+      absent(kubernetes_io:anthos_container_uptime{container_name=~"kube-controller-manager"}) * on(project_id, location, cluster_name) group_left() (kubernetes_io:anthos_anthos_cluster_info{monitored_resource="k8s_container", anthos_distribution="baremetal"})
+  displayName: Controller manager is up 
 displayName: Controller manager down (critical)

--- a/alerts/control-plane/scheduler-down.yaml
+++ b/alerts/control-plane/scheduler-down.yaml
@@ -14,31 +14,8 @@
 
 combiner: OR
 conditions:
-- conditionMonitoringQueryLanguage:
-    duration: 0s
-    query: |-
-      { t_0:
-          fetch k8s_container
-          | metric 'kubernetes.io/anthos/container/uptime'
-          | filter (resource.container_name =~ 'kube-scheduler')
-          | align mean_aligner()
-          | group_by 1m, [value_up_mean: mean(value.uptime)]
-          | every 1m
-          | group_by [resource.project_id, resource.location, resource.cluster_name],
-              [value_up_mean_aggregate: aggregate(value_up_mean)]
-      ; t_1:
-          fetch k8s_container::kubernetes.io/anthos/anthos_cluster_info
-          | filter (metric.anthos_distribution = 'baremetal')
-          | align mean_aligner()
-          | group_by [resource.project_id, resource.location, resource.cluster_name],
-              [value_anthos_cluster_info_aggregate:
-                 aggregate(value.anthos_cluster_info)]
-          | every 1m }
-      | join
-      | value [t_0.value_up_mean_aggregate]
-      | window 1m
-      | absent_for 300s
-    trigger:
-      count: 1
-  displayName: Scheduler is up
-displayName: Scheduler down (critical)
+- conditionPrometheusQueryLanguage:
+    duration: 300s
+    query: absent(kubernetes_io:anthos_container_uptime{container_name=~"kube-scheduler"} and on(project_id, location, cluster_name) kubernetes_io:anthos_anthos_cluster_info{anthos_distribution="baremetal", monitored_resource="k8s_container"})
+  displayName: Scheduler is up 
+displayName: Scheduler down (critical) 


### PR DESCRIPTION
## Overview
This PR migrates four critical Kubernetes Control Plane alert policies from Monitoring Query Language (MQL) to Prometheus Query Language (PromQL). This ensures consistency across our observability stack for GDC Connected Servers.

## Control Plane Alerts Migrated
The following files in `alerts/control-plane/` have been updated:
1.  **apiserver-down.yaml**: Alert for API Server availability.
2.  **api-server-error-ratio-5-percent.yaml**: Alert triggered when the API Server error rate exceeds 5%.
3.  **controller-manager-down.yaml**: Alert for the Kubernetes Controller Manager health.
4.  **scheduler-down.yaml**: Alert for the Kubernetes Scheduler health.

## Changes
- Converted `conditionMonitoringQueryLanguage` to `conditionPrometheusQueryLanguage`.
- Verified metrics syntax to ensure proper aggregation across clusters.
- Ensured the `managed: true` label is preserved for UI filtering in the Google Cloud Console.

## Validation Checklist
- [x] Verified PromQL queries via `gcloud alpha monitoring policies create` in Cloud Shell.
- [x] Checked monitored resource types (e.g., ensuring `k8s_container` or relevant control plane resources are used correctly).
- [x] Confirmed the manual deployment script (`create-alerts.sh`) successfully processes these files.

