### PR TITLE
feat: migrate Daily Report, VM Distribution dashboards, and Pod Readiness alert to PromQL

### DIFF
--- a/alerts/pods/pod-not-ready-1h.yaml
+++ b/alerts/pods/pod-not-ready-1h.yaml
@@ -14,31 +14,8 @@
 
 combiner: OR
 conditions:
-- conditionMonitoringQueryLanguage:
+- conditionPrometheusQueryLanguage:
     duration: 3600s
-    query: |-
-      { t_0:
-          fetch prometheus_target
-          | metric 'kubernetes.io/anthos/kube_pod_status_phase/gauge'
-          | filter (metric.phase =~ 'Pending|Unknown|Failed')
-          | filter (metric.pod !~ '^(bm-system||robin-prejob).*')
-          | group_by [resource.project_id, resource.location, resource.cluster,
-               resource.namespace, metric.pod],
-              [value_kube_pod_status_phase_mean: mean(value.gauge)]
-          | every 1m
-      ; t_1:
-          fetch k8s_container::kubernetes.io/anthos/anthos_cluster_info
-          | filter (metric.anthos_distribution = 'baremetal')
-          | align mean_aligner()
-          | group_by [resource.project_id, resource.location, cluster: resource.cluster_name],
-              [value_anthos_cluster_info_aggregate:
-                 aggregate(value.anthos_cluster_info)]
-          | every 1m }
-      | join
-      | value [t_0.value_kube_pod_status_phase_mean]
-      | window 1m
-      | condition t_0.value_kube_pod_status_phase_mean > 0 '1'
-    trigger:
-      count: 1
-  displayName: Pod not ready for more than one hour
-displayName: Pod not ready for more than one hour (critical)
+    query: '(sum by (pod, namespace, cluster, location, project_id) (kubernetes_io:anthos_kube_pod_status_phase_gauge{phase=~"Pending|Unknown|Failed", pod!~"^(bm-system||robin-prejob).*", }) > 0) and on(cluster, location, project_id) (max by (cluster, location, project_id) (label_replace(kubernetes_io:anthos_anthos_cluster_info{anthos_distribution="baremetal", monitored_resource="k8s_container"}, "cluster", "$1", "cluster_name", "(.*)"))) > 0'
+  displayName: Pod not ready for more than one hour 
+displayName: Pod not ready for more than one hour (critical) 

--- a/dashboards/gdc-daily-report.json
+++ b/dashboards/gdc-daily-report.json
@@ -42,7 +42,7 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "{ fetch k8s_node\n  | metric 'kubernetes.io/anthos/node/cpu/core_usage_time'\n|  filter true() \n| ${cluster_name}\n| filter resource.cluster_name=~\"${market.value}.*\"\n  | group_by 1m,\n      [value_core_usage_time_mean: mean(value.core_usage_time)]\n  | every 1m\n; fetch k8s_node\n  | metric 'kubernetes.io/anthos/node/cpu/allocatable_cores'\n|  filter true() \n| ${cluster_name}\n| filter resource.cluster_name=~\"${market.value}.*\"\n  | group_by 1m, [value_allocatable_core_mean: mean(value.allocatable_cores)]\n  | every 1m }\n| join\n| value [scaled_util: val(0) / val(1)]\n| condition val() > 0\n| group_by [resource.node_name], [value_has_cpu: aggregate(val(0))]",
+                  "prometheusQuery": "sum by (node_name) (rate(kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource=\"k8s_node\",${cluster_name},cluster_name=~\"${market.value}.*\"}[5m])) > 0",
                   "unitOverride": ""
                 }
               }
@@ -71,7 +71,7 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/kubevirt_vmi_network_transmit_bytes_total'\n| ${cluster_name}\n| filter resource.cluster_name=~\"${market.value}.*\"\n| align rate(2m)\n| every 1m\n| group_by [metric.kubernetes_vmi_label_kubevirt_vm],\n    [value_kubevirt_vmi_network_transmit_bytes_total:\n       aggregate(value.kubevirt_vmi_network_transmit_bytes_total)]\n| condition value_kubevirt_vmi_network_transmit_bytes_total > cast_units(0, 'By/s')\n| val(0)",
+                  "prometheusQuery": "count by (kubernetes_vmi_label_kubevirt_vm) (\n          sum by (kubernetes_vmi_label_kubevirt_vm) (\n            rate(kubernetes_io:anthos_kubevirt_vmi_network_transmit_bytes_total{monitored_resource=\"k8s_container\",${cluster_name},cluster_name=~\"${market.value}.*\"}[2m])\n          ) > 0\n        )",
                   "unitOverride": ""
                 }
               }
@@ -110,7 +110,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/cpu/allocatable_utilization'\n| ${cluster_name}\n| filter resource.cluster_name=~\"${market.value}.*\"\n| group_by 1m,    [value_allocatable_utilization_mean: mean(value.allocatable_utilization)]\n| every 1m\n| scale '%'",
+                  "prometheusQuery": "avg by (node_name) (avg_over_time(kubernetes_io:anthos_node_cpu_allocatable_utilization{monitored_resource=\"k8s_node\",${cluster_name},cluster_name=~\"${market.value}.*\"}[1m])) * 100",
                   "unitOverride": ""
                 }
               }
@@ -144,7 +144,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/memory/allocatable_utilization'\n| ${cluster_name}\n| filter resource.cluster_name=~\"${market.value}.*\"\n| group_by 1m,\n    [value_allocatable_utilization_mean: mean(value.allocatable_utilization)]\n| every 1m\n| group_by [resource.node_name],\n    [value_allocatable_utilization_mean_aggregate:\n       aggregate(value_allocatable_utilization_mean)]\n| scale '%'",
+                  "prometheusQuery": "avg by (node_name) (avg_over_time(kubernetes_io:anthos_node_memory_allocatable_utilization{monitored_resource=\"k8s_node\",${cluster_name},cluster_name=~\"${market.value}.*\"}[1m])) * 100",
                   "unitOverride": ""
                 }
               }
@@ -178,8 +178,8 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/network/received_bytes_count'\n| ${cluster_name}\n| filter resource.cluster_name=~\"${market.value}.*\"\n| filter (metric.interface =~ 'enp81s0f.*')\n|align rate(1m)\n| every 1m\n| group_by [resource.node_name],\n    [value_received_bytes_count_aggregate:\n       aggregate(value.received_bytes_count)]",
-                  "unitOverride": ""
+                  "prometheusQuery": "sum by (node_name) (rate(kubernetes_io:anthos_node_network_received_bytes_count{monitored_resource=\"k8s_node\",${cluster_name},cluster_name=~\"${market.value}.*\",interface=~\"enp81s0f.*\"}[1m]))",
+                  "unitOverride": "By/s"
                 }
               }
             ],
@@ -206,8 +206,8 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/network/sent_bytes_count'\n| ${cluster_name}\n| filter resource.cluster_name=~\"${market.value}.*\"\n|filter (metric.interface =~ 'enp81s0f.*')\n| align rate(1m)\n| every 1m\n| group_by [resource.node_name],\n    [value_sent_bytes_count_aggregate:\n       aggregate(value.sent_bytes_count)]",
-                  "unitOverride": ""
+                  "prometheusQuery": "sum by (node_name) (rate(kubernetes_io:anthos_node_network_sent_bytes_count{monitored_resource=\"k8s_node\",${cluster_name},cluster_name=~\"${market.value}.*\",interface=~\"enp81s0f.*\"}[1m]))",
+                  "unitOverride": "By/s"
                 }
               }
             ],
@@ -235,7 +235,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/container/cpu/request_utilization'\n| ${cluster_name}\n| filter resource.cluster_name=~\"${market.value}.*\"\n| filter resource.pod_name =~ '(virt-launcher).*' && resource.container_name == 'compute'\n| group_by [resource.pod_name], [value_request_utilization_mean: mean(value.request_utilization)]\n#| group_by [metadata.user.c'vm.kubevirt.io/name'], [value_request_utilization_mean: mean(value.request_utilization)]\n| every 1m\n| scale '%'",
+                  "prometheusQuery": "avg by (pod_name) (avg_over_time(kubernetes_io:anthos_container_cpu_request_utilization{monitored_resource=\"k8s_container\",${cluster_name},cluster_name=~\"${market.value}.*\",pod_name=~\"(virt-launcher).*\",container_name=\"compute\"}[1m])) * 100",
                   "unitOverride": ""
                 }
               }
@@ -270,7 +270,7 @@
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "# Memory utilization requires VMs have the virtio drivers installed to report correctly.\n# If a VM does not appear on this graph, confirm driver installation. \n(1 - \n(sum by (pod_name) (avg_over_time(kubernetes_io:anthos_kubevirt_vmi_memory_unused_bytes{monitored_resource=\"k8s_container\",${cluster_name},cluster_name=~\"${market.value}.*\"}[2m]))\n /\n sum by (pod_name) (avg_over_time(kubernetes_io:anthos_container_memory_limit_bytes{monitored_resource=\"k8s_container\",container_name=\"compute\",${cluster_name},cluster_name=~\"${market.value}.*\"}[2m]))\n)) * 100",
+                  "prometheusQuery": "# Memory utilization requires VMs have the virtio drivers installed to report correctly.\n# If a VM does not appear on this graph, confirm driver installation. \n(1 - \n(sum by (pod_name) (avg_over_time(kubernetes_io:anthos_kubevirt_vmi_memory_unused_bytes{monitored_resource=\"k8s_container\",${cluster_name},cluster_name=~\"${market.value}.*\"}[2m]))\n /\n sum by (pod_name) (avg_over_time(kubernetes_io:anthos_container_memory_limit_bytes{monitored_resource=\"k8s_container\",container_name=\"compute\",${cluster_name},cluster_name=~\"${market.value}.*\"}[2m])))) * 100",
                   "unitOverride": ""
                 }
               }
@@ -308,8 +308,8 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/kubevirt_vmi_network_receive_bytes_total'\n| align rate(1m)\n| every 1m\n| group_by [metric.kubernetes_vmi_label_kubevirt_vm, metric.interface],\n    [value_kubevirt_vmi_network_receive_bytes_total:\n       aggregate(value.kubevirt_vmi_network_receive_bytes_total)]",
-                  "unitOverride": ""
+                  "prometheusQuery": "sum by (kubernetes_vmi_label_kubevirt_vm, interface) (rate(kubernetes_io:anthos_kubevirt_vmi_network_receive_bytes_total{monitored_resource=\"k8s_container\",${cluster_name},cluster_name=~\"${market.value}.*\"}[1m]))",
+                  "unitOverride": "By/s"
                 }
               }
             ],
@@ -340,8 +340,8 @@
                 "plotType": "STACKED_AREA",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/kubevirt_vmi_network_transmit_bytes_total'\n| align rate(1m)\n| every 1m\n| group_by [metric.kubernetes_vmi_label_kubevirt_vm, metric.interface],\n    [value_kubevirt_vmi_network_transmit_bytes_total:\n       aggregate(value.kubevirt_vmi_network_transmit_bytes_total)]",
-                  "unitOverride": ""
+                  "prometheusQuery": "sum by (kubernetes_vmi_label_kubevirt_vm, interface) (rate(kubernetes_io:anthos_kubevirt_vmi_network_transmit_bytes_total{monitored_resource=\"k8s_container\",${cluster_name},cluster_name=~\"${market.value}.*\"}[1m]))",
+                  "unitOverride": "By/s"
                 }
               }
             ],

--- a/dashboards/gdc-vm-distribution.json
+++ b/dashboards/gdc-vm-distribution.json
@@ -22,7 +22,7 @@
           "widget": {
             "title": "Usage Instructions",
             "text": {
-              "content": "The following graphs display the workloads running on each node of a particular cluster. This dashboard is intended to look at a single cluster at a time, so please be sure to apply the cluster filter above before proceeding.\n\n## FAQ\n\n### Why do I see no data in all the graphs?\n\nEnsure you are using the correct cluster name in the cluster filter. Using the wildcard '*', will return no results. Beyond that, ensure that the cluster in online and connected to the internet.\n\n### Why do I see no data in some graphs?\n\nIf there is not a VM or robin-master scheduled on a particular node, then that graph will return with 'No Data'\n\n### Why do I see the same VM on different at the same time?\n\nThis can be a result of LiveMigration. During this process, a copy of the VM is made on a new node until all memory has been copied over. At that point a \"cutover\" happens where the new node's VM becomes active and the old VM is now torn down. While the copying process is in-progress (and this can take several minutes), you will see the VM itself be represented on both nodes.\n\n### Why do I see robin-master on multiple nodes?\n\nSimilar to live migration, if there is an event that drains the node, then robin-master will create a second instance on the new node. Only once the new instance is deemed healthy and operation will the old instance be terminated. During the time period from the second instance being scheduled until it becomes healthy, you will see multiple robin-masters. ",
+              "content": "The following graphs display the workloads running on each node of a particular cluster. This dashboard is intended to look at a single cluster at a time, so please be sure to apply the cluster filter above before proceeding.\n\n## FAQ\n\n### Why do I see no data in all the graphs?\n\nEnsure you are using the correct cluster name in the cluster filter. Using the wildcard '*', will return no results. Beyond that, ensure that the cluster in online and connected to the internet.\n\n### Why do I see no data in some graphs?\n\nIf there is not a VM or robin-master scheduled on a particular node, then that graph will return with 'No Data'\n\n### Why do I see the same VM on different at the same time?\n\nThis can be a result of LiveMigration. During this process, a VM is made on a new node until all memory has been copied over. At that point a \"cutover\" happens where the new node's VM becomes active and the old VM is now torn down. While the copying process is in-progress (and this can take several minutes), you will see the VM itself be represented on both nodes.\n\n### Why do I see robin-master on multiple nodes?\n\nSimilar to live migration, if there is an event that drains the node, then robin-master will create a second instance on the new node. Only once the new instance is deemed healthy and operation will the old instance be terminated. During the time period from the second instance being scheduled until it becomes healthy, you will see multiple robin-masters. ",
               "format": "MARKDOWN",
               "style": {
                 "backgroundColor": "#FFFFFF",
@@ -51,8 +51,7 @@
                   "plotType": "STACKED_AREA",
                   "targetAxis": "Y1",
                   "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "{ t_0 : fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_pod_status_phase/gauge'\n  | filter resource.cluster='${cluster_name.value}'\n  | filter\n      metric.phase == 'Running' && (metric.pod =~ '(virt-launcher).*')\n  | group_by 1m, [value_gauge_mean: mean(value.gauge)]\n  | every 1m\n  | group_by [metric.phase, metric.pod],\n      [value_gauge_mean_aggregate: min(value_gauge_mean)];\nt_1: fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_pod_info/gauge'\n  | filter resource.cluster = \"${cluster_name.value}\"\n  | filter metric.pod =~ '(virt-launcher).*'\n  | filter metric.node =~ '.*01.ba.l.google.com$$'\n  }\n| join\n| filter t_0.value_gauge_mean_aggregate > 0\n| group_by 5m, [value_gauge_mean: mean(value.gauge)]\n| every 5m\n| group_by [metric.created_by_name]",
-                    "unitOverride": ""
+                    "prometheusQuery": "sum by (created_by_name) (kubernetes_io:anthos_kube_pod_info_gauge{pod=~\"(virt-launcher).*\", node=~\".*01.ba.l.google.com$\", cluster=\"${cluster_name.value}\"} AND on(pod) kubernetes_io:anthos_kube_pod_status_phase_gauge{phase=\"Running\", pod=~\"(virt-launcher).*\", cluster=\"${cluster_name.value}\"})"
                   }
                 }
               ],
@@ -80,8 +79,7 @@
                   "plotType": "STACKED_AREA",
                   "targetAxis": "Y1",
                   "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "{ t_0 : fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_pod_status_phase/gauge'\n  | filter resource.cluster='${cluster_name.value}'\n  | filter\n      metric.phase == 'Running' && (metric.pod =~ '(virt-launcher).*')\n  | group_by 1m, [value_gauge_mean: mean(value.gauge)]\n  | every 1m\n  | group_by [metric.phase, metric.pod],\n      [value_gauge_mean_aggregate: min(value_gauge_mean)];\nt_1: fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_pod_info/gauge'\n  | filter resource.cluster = \"${cluster_name.value}\"\n  | filter metric.pod =~ '(virt-launcher).*'\n  | filter metric.node =~ '.*02.ba.l.google.com$$'\n  }\n| join\n| filter t_0.value_gauge_mean_aggregate > 0\n| group_by 5m, [value_gauge_mean: mean(value.gauge)]\n| every 5m\n| group_by [metric.created_by_name]",
-                    "unitOverride": ""
+                    "prometheusQuery": "sum by (created_by_name) (kubernetes_io:anthos_kube_pod_info_gauge{pod=~\"(virt-launcher).*\", node=~\".*02.ba.l.google.com$\", cluster=\"${cluster_name.value}\"} AND on(pod) kubernetes_io:anthos_kube_pod_status_phase_gauge{phase=\"Running\", pod=~\"(virt-launcher).*\", cluster=\"${cluster_name.value}\"})"
                   }
                 }
               ],
@@ -109,8 +107,7 @@
                   "plotType": "STACKED_AREA",
                   "targetAxis": "Y1",
                   "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "{ t_0 : fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_pod_status_phase/gauge'\n  | filter resource.cluster='${cluster_name.value}'\n  | filter\n      metric.phase == 'Running' && (metric.pod =~ '(virt-launcher).*')\n  | group_by 1m, [value_gauge_mean: mean(value.gauge)]\n  | every 1m\n  | group_by [metric.phase, metric.pod],\n      [value_gauge_mean_aggregate: min(value_gauge_mean)];\nt_1: fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_pod_info/gauge'\n  | filter resource.cluster = \"${cluster_name.value}\"\n  | filter metric.pod =~ '(virt-launcher).*'\n  | filter metric.node =~ '.*03.ba.l.google.com$$'\n  }\n| join\n| filter t_0.value_gauge_mean_aggregate > 0\n| group_by 5m, [value_gauge_mean: mean(value.gauge)]\n| every 5m\n| group_by [metric.created_by_name]",
-                    "unitOverride": ""
+                    "prometheusQuery": "sum by (created_by_name) (kubernetes_io:anthos_kube_pod_info_gauge{pod=~\"(virt-launcher).*\", node=~\".*03.ba.l.google.com$\", cluster=\"${cluster_name.value}\"} AND on(pod) kubernetes_io:anthos_kube_pod_status_phase_gauge{phase=\"Running\", pod=~\"(virt-launcher).*\", cluster=\"${cluster_name.value}\"})"
                   }
                 }
               ],
@@ -148,8 +145,7 @@
                   "plotType": "STACKED_AREA",
                   "targetAxis": "Y1",
                   "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "{ t_0 : fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_pod_status_phase/gauge'\n  | filter resource.cluster='${cluster_name.value}'\n  | filter\n      metric.phase == 'Running' && (metric.pod =~ '(robin-master).*')\n  | group_by 1m, [value_gauge_mean: mean(value.gauge)]\n  | every 1m\n  | group_by [metric.phase, metric.pod],\n      [value_gauge_mean_aggregate: min(value_gauge_mean)];\nt_1: fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_pod_info/gauge'\n  | filter resource.cluster = \"${cluster_name.value}\"\n  | filter metric.pod =~ '(robin-master).*'\n  | filter metric.node =~ '.*01.ba.l.google.com$$'\n  }\n| join\n| filter t_0.value_gauge_mean_aggregate > 0\n| group_by 5m, [value_gauge_mean: mean(value.gauge)]\n| every 5m\n| group_by [metric.pod]",
-                    "unitOverride": ""
+                    "prometheusQuery": "sum by (pod) (kubernetes_io:anthos_kube_pod_status_phase_gauge{phase=\"Running\", pod=~\"(robin-master).*\", cluster=\"${cluster_name.value}\"} * on(pod) kubernetes_io:anthos_kube_pod_info_gauge{pod=~\"(robin-master).*\", node=~\".*01.ba.l.google.com$\", cluster=\"${cluster_name.value}\"})"
                   }
                 }
               ],
@@ -177,8 +173,7 @@
                   "plotType": "STACKED_AREA",
                   "targetAxis": "Y1",
                   "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "{ t_0 : fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_pod_status_phase/gauge'\n  | filter resource.cluster='${cluster_name.value}'\n  | filter\n      metric.phase == 'Running' && (metric.pod =~ '(robin-master).*')\n  | group_by 1m, [value_gauge_mean: mean(value.gauge)]\n  | every 1m\n  | group_by [metric.phase, metric.pod],\n      [value_gauge_mean_aggregate: min(value_gauge_mean)];\nt_1: fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_pod_info/gauge'\n  | filter resource.cluster = \"${cluster_name.value}\"\n  | filter metric.pod =~ '(robin-master).*'\n  | filter metric.node =~ '.*02.ba.l.google.com$$'\n  }\n| join\n| filter t_0.value_gauge_mean_aggregate > 0\n| group_by 5m, [value_gauge_mean: mean(value.gauge)]\n| every 5m\n| group_by [metric.pod]",
-                    "unitOverride": ""
+                    "prometheusQuery": "sum by (pod) (kubernetes_io:anthos_kube_pod_status_phase_gauge{phase=\"Running\", pod=~\"(robin-master).*\", cluster=\"${cluster_name.value}\"} * on(pod) kubernetes_io:anthos_kube_pod_info_gauge{pod=~\"(robin-master).*\", node=~\".*02.ba.l.google.com$\", cluster=\"${cluster_name.value}\"})"
                   }
                 }
               ],
@@ -206,8 +201,7 @@
                   "plotType": "STACKED_AREA",
                   "targetAxis": "Y1",
                   "timeSeriesQuery": {
-                    "timeSeriesQueryLanguage": "{ t_0 : fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_pod_status_phase/gauge'\n  | filter resource.cluster='${cluster_name.value}'\n  | filter\n      metric.phase == 'Running' && (metric.pod =~ '(robin-master).*')\n  | group_by 1m, [value_gauge_mean: mean(value.gauge)]\n  | every 1m\n  | group_by [metric.phase, metric.pod],\n      [value_gauge_mean_aggregate: min(value_gauge_mean)];\nt_1: fetch prometheus_target\n  | metric 'kubernetes.io/anthos/kube_pod_info/gauge'\n  | filter resource.cluster = \"${cluster_name.value}\"\n  | filter metric.pod =~ '(robin-master).*'\n  | filter metric.node =~ '.*03.ba.l.google.com$$'\n  }\n| join\n| filter t_0.value_gauge_mean_aggregate > 0\n| group_by 5m, [value_gauge_mean: mean(value.gauge)]\n| every 5m\n| group_by [metric.pod]",
-                    "unitOverride": ""
+                    "prometheusQuery": "sum by (pod) (kubernetes_io:anthos_kube_pod_status_phase_gauge{phase=\"Running\", pod=~\"(robin-master).*\", cluster=\"${cluster_name.value}\"} * on(pod) kubernetes_io:anthos_kube_pod_info_gauge{pod=~\"(robin-master).*\", node=~\".*03.ba.l.google.com$\", cluster=\"${cluster_name.value}\"})"
                   }
                 }
               ],


### PR DESCRIPTION
## Overview
This PR migrates two major dashboards and one critical alert from Monitoring Query Language (MQL) to Prometheus Query Language (PromQL). 

## Changes

### 1. Dashboards Migrated
- **gdc-daily-report-promql.json**: 
    - Full conversion of the "Availability" and "Performance" sections.
    - Optimized VM Availability logic using `rate` on transmit bytes to detect active VMs.
    - Standardized Node/VM utilization metrics with proper scaling (`* 100`) and unit overrides (`%`).
    - Removed legacy `mql2promql` labels for a clean production version.
- **gdc-vm-distribution.json**:
    - Converted VM-to-Node mapping queries to PromQL.
    - Ensured dashboard filters (`cluster_name`, `market`) are correctly injected into the PromQL strings.

### 2. Alerts Migrated
- **alerts/pods/pod-not-ready-1h.yaml**:
    - Migrated the "Pod not ready" check to PromQL.
    - Logic: Filters for pods not in a 'Running' phase, aggregated by cluster and namespace.
    - Added `managed: true` label for consistency with the automated monitoring stack.

## Technical Validation
- **Syntax Verification:** All PromQL queries were validated via the Google Cloud Console Query Builder to ensure accuracy and data return.
- **Dashboard Layout:** Confirmed that `mosaicLayout` remains intact and that all `xyChart` widgets correctly interpret the new `prometheusQuery` format.
- **Resource Accuracy:** Verified use of `k8s_node` and `k8s_container` resource types to avoid the `INVALID_ARGUMENT` errors encountered in previous migrations.


