### PR TITLE
Adding new and updating existing GDC observability dashboards.

### DIFF
--- a/dashboards/gdc-cluster-view.json
+++ b/dashboards/gdc-cluster-view.json
@@ -1,0 +1,282 @@
+{
+  "displayName": "GDC - Cluster View",
+  "dashboardFilters": [
+    {
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "cluster_name",
+      "stringValue": "",
+      "templateVariable": "cluster_name",
+      "valueType": "STRING"
+    },
+    {
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "project_id",
+      "stringValue": "",
+      "templateVariable": "project_id",
+      "valueType": "STRING"
+    }
+  ],
+  "description": "",
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 48,
+    "tiles": [
+      {
+        "height": 18,
+        "width": 24,
+        "widget": {
+          "title": "Fleet Connectivity to GCP %",
+          "id": "",
+          "scorecard": {
+            "breakdowns": [],
+            "dimensions": [],
+            "gaugeView": {
+              "lowerBound": 0,
+              "upperBound": 100
+            },
+            "measures": [],
+            "thresholds": [
+              {
+                "color": "YELLOW",
+                "direction": "BELOW",
+                "label": "",
+                "targetAxis": "TARGET_AXIS_UNSPECIFIED",
+                "value": 95
+              },
+              {
+                "color": "RED",
+                "direction": "BELOW",
+                "label": "",
+                "targetAxis": "TARGET_AXIS_UNSPECIFIED",
+                "value": 70
+              }
+            ],
+            "timeSeriesQuery": {
+              "outputFullDuration": true,
+              "prometheusQuery": "(\n \n  sum(\n    count_over_time(\n      (\n        count_over_time(\n          {\n            __name__=\"kubernetes.io/anthos/node/cpu/allocatable_cores\",\n            cluster_name=~\"${cluster_name.value}\",\n            project_id=~\"${project_id.value}\"\n          }[5m] # have we seen anything in the last 5 mins as a heartbeat\n        ) \n      )[${__interval}:5m]  # how many ups have we seen in 5 min chunks over the interval\n    )\n  )\n  or vector(0)\n)\n/\n(\n  ### DENOMINATOR: (Total Inventory) * (Max possible 5m intervals)\n  (\n    sum(\n      count by (node_name) (\n        last_over_time(\n          {\n            __name__=\"kubernetes.io/anthos/node/cpu/allocatable_cores\",\n            cluster_name=~\"${cluster_name.value}\",\n            project_id=~\"${project_id.value}\"\n          }[10d] # we decided to place this hardcoded as a value of how many days should we consider that a cluster is part of the inventory\n        )\n      )\n    )\n  )\n  * ### Calculates how many 5m steps exist in the current dashboard interval\n  ### e.g., if interval is 1h, this returns 12.\n  count_over_time(vector(1)[${__interval}:5m])\n)\n* 100",
+              "unitOverride": ""
+            }
+          }
+        }
+      },
+      {
+        "xPos": 24,
+        "height": 18,
+        "width": 24,
+        "widget": {
+          "title": "Version Count",
+          "id": "",
+          "pieChart": {
+            "chartType": "DONUT",
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "measures": [],
+                "sliceNameTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "count by (version) (\n  max by (cluster_name, version) (\n    avg_over_time(\n      {\n        __name__=\"edgecontainer.googleapis.com/edge_cluster/current_cluster_version\",\n        monitored_resource=\"edgecontainer.googleapis.com/EdgeCluster\",\n        cluster_name=~\"${cluster_name.value}\"\n      }[24h]\n    )\n  )\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "showLabels": false,
+            "showTotal": false,
+            "sliceAggregatedThreshold": 0
+          }
+        }
+      },
+      {
+        "yPos": 18,
+        "height": 18,
+        "width": 24,
+        "widget": {
+          "title": "Cluster Version",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [
+              {
+                "column": "cluster_name",
+                "visible": true
+              },
+              {
+                "column": "version",
+                "visible": true
+              },
+              {
+                "column": "value",
+                "visible": false
+              }
+            ],
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "count by (version, cluster_name) (\n  avg_over_time({\n    __name__=\"edgecontainer.googleapis.com/edge_cluster/current_cluster_version\",\n    monitored_resource=\"edgecontainer.googleapis.com/EdgeCluster\",\n    cluster_name=~\"${cluster_name.value}\"\n  }[24h])\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "yPos": 18,
+        "xPos": 24,
+        "height": 18,
+        "width": 24,
+        "widget": {
+          "title": "Cluster currently being upgraded within 24h",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [
+              {
+                "column": "cluster_name",
+                "visible": true
+              },
+              {
+                "column": "status",
+                "visible": true
+              },
+              {
+                "column": "value",
+                "visible": false
+              },
+              {
+                "column": "current_node_version",
+                "visible": false
+              }
+            ],
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "(\n  # ---------------------------------------------------------------------\n  # PART A: Clusters in explicit failure states\n  # Result Status: RECONCILING, PROVISIONING, or ERROR\n  # ---------------------------------------------------------------------\n  max by (status, cluster_name) (\n    last_over_time({\n      __name__=\"edgecontainer.googleapis.com/edge_cluster/lifecycle_status\",\n      monitored_resource=\"edgecontainer.googleapis.com/EdgeCluster\",\n      status=~\"RECONCILING|PROVISIONING|ERROR\",\n      cluster_name=~\"${cluster_name.value}\"\n    }[24h])\n  )\n)\nOR on (cluster_name) (\n  # ---------------------------------------------------------------------\n  # PART B: Clusters that are RUNNING but have Version Drift\n  # Result Status: Overwritten to \"UPGRADE_PAUSED\"\n  # ---------------------------------------------------------------------\n  label_replace(\n    (\n      # 1. Calculate Drift (Node != Cluster)\n      (\n        max by (cluster_name, current_node_version) (\n          last_over_time({\n            __name__=\"edgecontainer.googleapis.com/node/current_node_version\",\n            monitored_resource=\"edgecontainer.googleapis.com/Node\"\n          }[24h])\n        )\n        unless on (cluster_name, current_node_version)\n        label_replace(\n          max by (cluster_name, version) (\n            last_over_time({\n              __name__=\"edgecontainer.googleapis.com/edge_cluster/current_cluster_version\",\n              monitored_resource=\"edgecontainer.googleapis.com/EdgeCluster\"\n            }[24h])\n          ),\n          \"current_node_version\", \"$1\", \"version\", \"(.*)\"\n        )\n      )\n      # 2. Guard: Ensure it's technically RUNNING, and pull that label in\n      * on (cluster_name) group_left(status)\n      max by (cluster_name, status) (\n        last_over_time({\n          __name__=\"edgecontainer.googleapis.com/edge_cluster/lifecycle_status\",\n          monitored_resource=\"edgecontainer.googleapis.com/EdgeCluster\",\n          status=\"RUNNING\",\n          cluster_name=~\"${cluster_name.value}\"\n        }[24h])\n      )\n    ),\n    # 3. Rename \"RUNNING\" to \"UPGRADE_PAUSED\" for readability\n    \"status\", \"UPGRADE_PAUSED\", \"status\", \".*\"\n  )\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "yPos": 36,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Incidents",
+          "id": "",
+          "incidentList": {
+            "groupBy": "GROUP_BY_TYPE_UNSPECIFIED",
+            "monitoredResources": [],
+            "policyNames": [],
+            "userLabels": {}
+          }
+        }
+      },
+      {
+        "yPos": 36,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Cluster with one or more node down in last 10 days",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [
+              {
+                "column": "cluster_name",
+                "visible": true
+              },
+              {
+                "column": "version",
+                "visible": false
+              },
+              {
+                "column": "value",
+                "visible": false
+              },
+              {
+                "column": "monitored_resource",
+                "visible": false
+              },
+              {
+                "column": "project_id",
+                "visible": false
+              },
+              {
+                "column": "node_name",
+                "visible": true
+              },
+              {
+                "column": "location",
+                "visible": true
+              },
+              {
+                "column": "status",
+                "visible": false
+              }
+            ],
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "(\n  max_over_time(kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource=\"k8s_node\", project_id=~\"${project_id.value}\"}[10d]) \n  unless \n  kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource=\"k8s_node\", project_id=~\"${project_id.value}\"}\n)\nand on(cluster_name)\n(\n  count by (cluster_name) (\n    kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource=\"k8s_node\", project_id=~\"${project_id.value}\"}\n  ) < 3\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "yPos": 52,
+        "height": 8,
+        "width": 14,
+        "widget": {
+          "title": "Populate Cluster List Helper - Do Not Remove",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [],
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "600s",
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "600s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "resource.label.\"cluster_name\""
+                      ],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"kubernetes.io/anthos/node/cpu/total_cores\" resource.type=\"k8s_node\" ${cluster_name} ${project_id}"
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/dashboards/gdc-daily-report.json
+++ b/dashboards/gdc-daily-report.json
@@ -2,121 +2,199 @@
   "displayName": "GDC - Daily Report",
   "dashboardFilters": [
     {
+      "comparator": "COMPARATOR_UNSPECIFIED",
       "filterType": "RESOURCE_LABEL",
       "labelKey": "cluster_name",
-      "stringValue": "",
-      "templateVariable": "cluster_name"
+      "stringValue": "None",
+      "templateVariable": "cluster_name",
+      "valueType": "STRING"
     },
     {
+      "comparator": "COMPARATOR_UNSPECIFIED",
       "filterType": "RESOURCE_LABEL",
-      "labelKey": "market",
+      "labelKey": "project_id",
       "stringValue": "",
-      "templateVariable": "market"
+      "templateVariable": "project_id",
+      "valueType": "STRING"
+    },
+    {
+      "comparator": "COMPARATOR_UNSPECIFIED",
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "machine_id",
+      "stringValue": "",
+      "templateVariable": "machine_id",
+      "valueType": "STRING"
     }
   ],
+  "description": "",
+  "labels": {},
   "mosaicLayout": {
     "columns": 48,
     "tiles": [
       {
+        "height": 10,
+        "width": 47,
+        "widget": {
+          "title": "Node Availability",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "(\n  sum by (node_name) (\n    rate({\n      __name__=\"kubernetes.io/anthos/node/cpu/core_usage_time\",\n      monitored_resource=\"k8s_node\",\n      cluster_name=~\"${cluster_name.value}\",\n      project_id=~\"${project_id.value}\"\n    }[1m])\n  )\n  /\n  sum by (node_name) (\n    avg_over_time({\n      __name__=\"kubernetes.io/anthos/node/cpu/allocatable_cores\",\n      monitored_resource=\"k8s_node\",\n      cluster_name=~\"${cluster_name.value}\",\n      project_id=~\"${project_id.value}\"\n    }[1m])\n  )\n) > 0",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 10,
+        "height": 11,
+        "width": 47,
+        "widget": {
+          "title": "VM Availability",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (kubernetes_vmi_label_kubevirt_vm) (\n  rate({\n    __name__=\"kubernetes.io/anthos/kubevirt_vmi_network_transmit_bytes_total\",\n    monitored_resource=\"k8s_container\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\"\n  }[2m])\n) > 0",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 21,
+        "height": 12,
         "width": 48,
-        "height": 21,
         "widget": {
           "title": "Availability",
           "collapsibleGroup": {
             "collapsed": false
-          }
-        }
-      },
-      {
-        "xPos": 1,
-        "width": 47,
-        "height": 10,
-        "widget": {
-          "title": "Node Availability",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "STACKED_AREA",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (node_name) (rate(kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource=\"k8s_node\",${cluster_name},cluster_name=~\"${market.value}.*\"}[5m])) > 0",
-                  "unitOverride": ""
-                }
-              }
-            ],
-            "thresholds": [],
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "xPos": 1,
-        "yPos": 10,
-        "width": 47,
-        "height": 11,
-        "widget": {
-          "title": "VM Availability",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "STACKED_AREA",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "prometheusQuery": "count by (kubernetes_vmi_label_kubevirt_vm) (\n          sum by (kubernetes_vmi_label_kubevirt_vm) (\n            rate(kubernetes_io:anthos_kubevirt_vmi_network_transmit_bytes_total{monitored_resource=\"k8s_container\",${cluster_name},cluster_name=~\"${market.value}.*\"}[2m])\n          ) > 0\n        )",
-                  "unitOverride": ""
-                }
-              }
-            ],
-            "thresholds": [],
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
+          },
+          "id": ""
         }
       },
       {
         "yPos": 21,
-        "width": 48,
-        "height": 45,
+        "xPos": 1,
+        "height": 12,
+        "width": 47,
         "widget": {
-          "title": "Peformance",
-          "collapsibleGroup": {
-            "collapsed": false
+          "title": "Machine Connected to GCP",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [
+              {
+                "column": "machine_id",
+                "visible": true
+              },
+              {
+                "column": "cluster_name",
+                "visible": true
+              },
+              {
+                "column": "status",
+                "visible": true
+              },
+              {
+                "column": "value",
+                "visible": true
+              }
+            ],
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": true,
+                  "prometheusQuery": "label_replace(\n  (\n    max by (machine_id) (\n      last_over_time({\n        __name__=\"edgecontainer.googleapis.com/machine/connected\",\n        monitored_resource=\"edgecontainer.googleapis.com/Machine\",\n        machine_id=~\"${machine_id.value}\"\n      }[${__interval}])\n    ) == 1\n  )\n  * on (machine_id) group_left(cluster_name)\n  (\n    label_replace(\n      max by (cluster_name, machine_name) (\n        last_over_time({\n          __name__=\"edgecontainer.googleapis.com/node/current_node_version\",\n          monitored_resource=\"edgecontainer.googleapis.com/Node\",\n          cluster_name=~\"${cluster_name.value}\"\n        }[5m])\n      ),\n      \"machine_id\", \"$1\", \"machine_name\", \".*/machines/(.*)\"\n    )\n  ),\n  \"status\", \"Connected\", \"\", \"\"\n)\nOR\nlabel_replace(\n  (\n    max by (machine_id) (\n      last_over_time({\n        __name__=\"edgecontainer.googleapis.com/machine/connected\",\n        monitored_resource=\"edgecontainer.googleapis.com/Machine\",\n        machine_id=~\"${machine_id.value}\"\n      }[${__interval}])\n    ) == 0\n  )\n  * on (machine_id) group_left(cluster_name)\n  (\n    label_replace(\n      max by (cluster_name, machine_name) (\n        last_over_time({\n          __name__=\"edgecontainer.googleapis.com/node/current_node_version\",\n          monitored_resource=\"edgecontainer.googleapis.com/Node\",\n          cluster_name=~\"${cluster_name.value}\"\n        }[5m])\n      ),\n      \"machine_id\", \"$1\", \"machine_name\", \".*/machines/(.*)\"\n    )\n  ),\n  \"status\", \"Disconnected\", \"\", \"\"\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
           }
         }
       },
       {
-        "yPos": 21,
-        "width": 24,
+        "yPos": 33,
         "height": 9,
+        "width": 24,
         "widget": {
           "title": "Node CPU Utilization",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
+                "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (node_name) (avg_over_time(kubernetes_io:anthos_node_cpu_allocatable_utilization{monitored_resource=\"k8s_node\",${cluster_name},cluster_name=~\"${market.value}.*\"}[1m])) * 100",
+                  "outputFullDuration": false,
+                  "prometheusQuery": "avg_over_time({\n  __name__=\"kubernetes.io/anthos/node/cpu/allocatable_utilization\",\n  monitored_resource=\"k8s_node\",\n  cluster_name=~\"${cluster_name.value}\",\n  project_id=~\"${project_id.value}\"\n}[1m]) * 100",
                   "unitOverride": ""
                 }
               }
             ],
             "thresholds": [
               {
+                "color": "COLOR_UNSPECIFIED",
+                "direction": "DIRECTION_UNSPECIFIED",
                 "label": "",
                 "targetAxis": "Y1",
                 "value": 25
@@ -130,27 +208,98 @@
         }
       },
       {
-        "yPos": 30,
-        "width": 24,
-        "height": 9,
+        "yPos": 33,
+        "height": 45,
+        "width": 48,
         "widget": {
-          "title": "Node Memory Utilization",
+          "title": "Peformance",
+          "collapsibleGroup": {
+            "collapsed": false
+          },
+          "id": ""
+        }
+      },
+      {
+        "yPos": 33,
+        "xPos": 24,
+        "height": 9,
+        "width": 24,
+        "widget": {
+          "title": "VM CPU Utilization",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
+                "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (node_name) (avg_over_time(kubernetes_io:anthos_node_memory_allocatable_utilization{monitored_resource=\"k8s_node\",${cluster_name},cluster_name=~\"${market.value}.*\"}[1m])) * 100",
+                  "outputFullDuration": false,
+                  "prometheusQuery": "avg by (pod_name) (\n  avg_over_time({\n    __name__=\"kubernetes.io/anthos/container/cpu/request_utilization\",\n    monitored_resource=\"k8s_container\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\",\n    pod_name=~\"virt-launcher.*\",\n    container_name=\"compute\"\n  }[1m])\n) * 100",
                   "unitOverride": ""
                 }
               }
             ],
             "thresholds": [
               {
+                "color": "COLOR_UNSPECIFIED",
+                "direction": "DIRECTION_UNSPECIFIED",
+                "label": "",
+                "targetAxis": "Y1",
+                "value": 25
+              }
+            ],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 42,
+        "height": 9,
+        "width": 24,
+        "widget": {
+          "title": "Node Memory Utilization",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (node_name) (\n  avg_over_time({\n    __name__=\"kubernetes.io/anthos/node/memory/allocatable_utilization\",\n    monitored_resource=\"k8s_node\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\"\n  }[1m])\n) * 100",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [
+              {
+                "color": "COLOR_UNSPECIFIED",
+                "direction": "DIRECTION_UNSPECIFIED",
                 "label": "",
                 "targetAxis": "Y1",
                 "value": 65
@@ -164,119 +313,40 @@
         }
       },
       {
-        "yPos": 39,
-        "width": 24,
-        "height": 8,
-        "widget": {
-          "title": "Node Received Bytes",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "STACKED_AREA",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (node_name) (rate(kubernetes_io:anthos_node_network_received_bytes_count{monitored_resource=\"k8s_node\",${cluster_name},cluster_name=~\"${market.value}.*\",interface=~\"enp81s0f.*\"}[1m]))",
-                  "unitOverride": "By/s"
-                }
-              }
-            ],
-            "thresholds": [],
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "yPos": 47,
-        "width": 24,
-        "height": 10,
-        "widget": {
-          "title": "Node Sent Bytes",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "STACKED_AREA",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (node_name) (rate(kubernetes_io:anthos_node_network_sent_bytes_count{monitored_resource=\"k8s_node\",${cluster_name},cluster_name=~\"${market.value}.*\",interface=~\"enp81s0f.*\"}[1m]))",
-                  "unitOverride": "By/s"
-                }
-              }
-            ],
-            "thresholds": [],
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
+        "yPos": 42,
         "xPos": 24,
-        "yPos": 21,
-        "width": 24,
         "height": 9,
-        "widget": {
-          "title": "VM CPU Utilization",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "prometheusQuery": "avg by (pod_name) (avg_over_time(kubernetes_io:anthos_container_cpu_request_utilization{monitored_resource=\"k8s_container\",${cluster_name},cluster_name=~\"${market.value}.*\",pod_name=~\"(virt-launcher).*\",container_name=\"compute\"}[1m])) * 100",
-                  "unitOverride": ""
-                }
-              }
-            ],
-            "thresholds": [
-              {
-                "label": "",
-                "targetAxis": "Y1",
-                "value": 25
-              }
-            ],
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "xPos": 24,
-        "yPos": 30,
         "width": 24,
-        "height": 9,
         "widget": {
           "title": "VM Memory Utilization",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
+                "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "# Memory utilization requires VMs have the virtio drivers installed to report correctly.\n# If a VM does not appear on this graph, confirm driver installation. \n(1 - \n(sum by (pod_name) (avg_over_time(kubernetes_io:anthos_kubevirt_vmi_memory_unused_bytes{monitored_resource=\"k8s_container\",${cluster_name},cluster_name=~\"${market.value}.*\"}[2m]))\n /\n sum by (pod_name) (avg_over_time(kubernetes_io:anthos_container_memory_limit_bytes{monitored_resource=\"k8s_container\",container_name=\"compute\",${cluster_name},cluster_name=~\"${market.value}.*\"}[2m])))) * 100",
+                  "outputFullDuration": false,
+                  "prometheusQuery": "# Memory utilization requires VMs have the virtio drivers installed to report correctly.\n# If a VM does not appear on this graph, confirm driver installation.\n(1 -\n(sum by (pod_name) (avg_over_time(kubernetes_io:anthos_kubevirt_vmi_memory_unused_bytes{monitored_resource=\"k8s_container\",cluster_name=~\"${cluster_name.value}\",project_id=~\"${project_id.value}\"}[2m]))\n /\n sum by (pod_name) (avg_over_time(kubernetes_io:anthos_container_memory_limit_bytes{monitored_resource=\"k8s_container\",container_name=\"compute\",cluster_name=~\"${cluster_name.value}\",project_id=~\"${project_id.value}\"}[2m]))\n)) * 100",
                   "unitOverride": ""
                 }
               }
             ],
             "thresholds": [
               {
+                "color": "COLOR_UNSPECIFIED",
+                "direction": "DIRECTION_UNSPECIFIED",
                 "label": "",
                 "targetAxis": "Y1",
                 "value": 40
@@ -290,92 +360,36 @@
         }
       },
       {
-        "xPos": 24,
-        "yPos": 39,
-        "width": 24,
+        "yPos": 51,
         "height": 8,
+        "width": 24,
         "widget": {
-          "title": "VM Received Bytes (Per Interface)",
+          "title": "Node Received Bytes",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
+                "minAlignmentPeriod": "60s",
                 "plotType": "STACKED_AREA",
+                "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (kubernetes_vmi_label_kubevirt_vm, interface) (rate(kubernetes_io:anthos_kubevirt_vmi_network_receive_bytes_total{monitored_resource=\"k8s_container\",${cluster_name},cluster_name=~\"${market.value}.*\"}[1m]))",
-                  "unitOverride": "By/s"
-                }
-              }
-            ],
-            "thresholds": [],
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "xPos": 24,
-        "yPos": 47,
-        "width": 24,
-        "height": 10,
-        "widget": {
-          "title": "VM Sent Bytes (Per Interface)",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "measures": [],
-                "plotType": "STACKED_AREA",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (kubernetes_vmi_label_kubevirt_vm, interface) (rate(kubernetes_io:anthos_kubevirt_vmi_network_transmit_bytes_total{monitored_resource=\"k8s_container\",${cluster_name},cluster_name=~\"${market.value}.*\"}[1m]))",
-                  "unitOverride": "By/s"
-                }
-              }
-            ],
-            "thresholds": [],
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        }
-      },
-      {
-        "xPos": 24,
-        "yPos": 57,
-        "height": 9,
-        "width": 24,
-        "widget": {
-          "title": "Storage Write iops (Per VM)",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "plotType": "LINE",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (kubernetes_vmi_label_kubevirt_vm)(rate(kubernetes_io:anthos_kubevirt_vmi_storage_iops_write_total{monitored_resource=\"k8s_container\",${cluster_name},cluster_name=~\"${market.value}.*\"}[2m]))",
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (node_name) (\n  rate({\n    __name__=\"kubernetes.io/anthos/node/network/received_bytes_count\",\n    monitored_resource=\"k8s_node\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\",\n    interface=~\"enp81s0f.*\"\n  }[1m])\n)",
                   "unitOverride": ""
                 }
               }
             ],
             "thresholds": [],
-            "timeshiftDuration": "0s",
             "yAxis": {
               "label": "",
               "scale": "LINEAR"
@@ -384,21 +398,147 @@
         }
       },
       {
-        "yPos": 57,
+        "yPos": 51,
+        "xPos": 24,
+        "height": 8,
+        "width": 24,
+        "widget": {
+          "title": "VM Received Bytes (Per Interface)",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (kubernetes_vmi_label_kubevirt_vm, interface) (\n  rate({\n    __name__=\"kubernetes.io/anthos/kubevirt_vmi_network_receive_bytes_total\",\n    monitored_resource=\"k8s_container\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\"\n  }[1m])\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 59,
+        "height": 10,
+        "width": 24,
+        "widget": {
+          "title": "Node Sent Bytes",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (node_name) (\n  rate({\n    __name__=\"kubernetes.io/anthos/node/network/sent_bytes_count\",\n    monitored_resource=\"k8s_node\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\",\n    interface=~\"enp81s0f.*\"\n  }[1m])\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 59,
+        "xPos": 24,
+        "height": 10,
+        "width": 24,
+        "widget": {
+          "title": "VM Sent Bytes (Per Interface)",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (kubernetes_vmi_label_kubevirt_vm, interface) (\n  rate({\n    __name__=\"kubernetes.io/anthos/kubevirt_vmi_network_transmit_bytes_total\",\n    monitored_resource=\"k8s_container\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\"\n  }[1m])\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 69,
         "height": 9,
         "width": 24,
         "widget": {
           "title": "Storage Read iops (Per VM)",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
+                "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (kubernetes_vmi_label_kubevirt_vm)(rate(kubernetes_io:anthos_kubevirt_vmi_storage_iops_read_total{monitored_resource=\"k8s_container\",${cluster_name},cluster_name=~\"${market.value}.*\"}[2m]))",
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (kubernetes_vmi_label_kubevirt_vm)(rate(kubernetes_io:anthos_kubevirt_vmi_storage_iops_read_total{monitored_resource=\"k8s_container\",cluster_name=~\"${cluster_name.value}\",project_id=~\"${project_id.value}\"}[2m]))",
                   "unitOverride": ""
                 }
               }
@@ -411,8 +551,341 @@
             }
           }
         }
+      },
+      {
+        "yPos": 69,
+        "xPos": 24,
+        "height": 9,
+        "width": 24,
+        "widget": {
+          "title": "Storage Write iops (Per VM)",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (kubernetes_vmi_label_kubevirt_vm)(rate(kubernetes_io:anthos_kubevirt_vmi_storage_iops_write_total{monitored_resource=\"k8s_container\",cluster_name=~\"${cluster_name.value}\",project_id=~\"${project_id.value}\"}[2m]))",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "timeshiftDuration": "0s",
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 78,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Incidents",
+          "id": "",
+          "incidentList": {
+            "groupBy": "GROUP_BY_TYPE_UNSPECIFIED",
+            "monitoredResources": [],
+            "policyNames": [],
+            "userLabels": {}
+          }
+        }
+      },
+      {
+        "yPos": 78,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Storage_iops_write [Disk-IOPS Write]",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "resource.label.\"cluster_name\""
+                      ],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_storage_iops_write_total\" resource.type=\"k8s_container\" ${cluster_name} ${project_id}"
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 94,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Storage_iops_read [Disk-IOPS Read]",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "resource.label.\"cluster_name\""
+                      ],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_storage_iops_read_total\" resource.type=\"k8s_container\" ${cluster_name} ${project_id}"
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 94,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Network_transmit_bytes_total",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "resource.label.\"cluster_name\""
+                      ],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_transmit_bytes_total\" resource.type=\"k8s_container\" ${cluster_name} ${project_id}"
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 110,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Network_receive_bytes_total",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "resource.label.\"cluster_name\""
+                      ],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_receive_bytes_total\" resource.type=\"k8s_container\" ${cluster_name} ${project_id}"
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 110,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "VM Failover & Restart Time -kubevirt_info",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "resource.label.\"cluster_name\"",
+                        "resource.label.\"pod_name\""
+                      ],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_info\" resource.type=\"k8s_container\" ${cluster_name} ${project_id}"
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 126,
+        "height": 8,
+        "width": 14,
+        "widget": {
+          "title": "Populate Machine List Helper - Do Not Remove",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [],
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "600s",
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "600s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "resource.label.\"machine_id\""
+                      ],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"edgecontainer.googleapis.com/machine/connected\" resource.type=\"edgecontainer.googleapis.com/Machine\" ${machine_id} ${project_id}"
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
       }
     ]
-  },
-  "labels": {}
+  }
 }

--- a/dashboards/gdc-environmental-monitoring.json
+++ b/dashboards/gdc-environmental-monitoring.json
@@ -1,0 +1,245 @@
+{
+  "displayName": "GDC - Environmental Monitoring",
+  "dashboardFilters": [
+    {
+      "comparator": "COMPARATOR_UNSPECIFIED",
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "cluster_name",
+      "stringValue": "",
+      "templateVariable": "cluster_name",
+      "valueType": "STRING"
+    },
+    {
+      "comparator": "COMPARATOR_UNSPECIFIED",
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "machine_id",
+      "stringValue": "",
+      "templateVariable": "machine_id",
+      "valueType": "STRING"
+    },
+    {
+      "comparator": "COMPARATOR_UNSPECIFIED",
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "project_id",
+      "stringValue": "",
+      "templateVariable": "project_id",
+      "valueType": "STRING"
+    }
+  ],
+  "description": "",
+  "labels": {},
+  "mosaicLayout": {
+    "columns": 48,
+    "tiles": [
+      {
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Low Power Servers (likely needing remediation)",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [],
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "(\n  avg by (machine_id) (\n    avg_over_time({\n      __name__=\"edgecontainer.googleapis.com/machine/power_consumption\",\n      monitored_resource=\"edgecontainer.googleapis.com/Machine\",\n      machine_id=~\"${machine_id.value}\"\n    }[${__interval}])\n  ) < 125\n)\n* on (machine_id) group_left(cluster_name)\n(\n  label_replace(\n    max by (cluster_name, machine_name) (\n      last_over_time({\n        __name__=\"edgecontainer.googleapis.com/node/current_node_version\",\n        monitored_resource=\"edgecontainer.googleapis.com/Node\",\n        cluster_name=~\"${cluster_name.value}\"\n      }[5m])\n    ),\n    \"machine_id\", \"$1\", \"machine_name\", \".*/machines/(.*)\"\n  )\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Machine Restarts",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "plotType": "LINE",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "(\n  sum by (machine_id) (\n    rate({\n      __name__=\"edgecontainer.googleapis.com/machine/restart_count\",\n      monitored_resource=\"edgecontainer.googleapis.com/Machine\",\n      machine_id=~\"${machine_id.value}\"\n    }[${__interval}])\n  )\n)\n* on (machine_id) group_left(cluster_name)\n(\n  label_replace(\n    max by (cluster_name, machine_name) (\n      last_over_time({\n        __name__=\"edgecontainer.googleapis.com/node/current_node_version\",\n        monitored_resource=\"edgecontainer.googleapis.com/Node\",\n        cluster_name=~\"${cluster_name.value}\"\n      }[5m])\n    ),\n    \"machine_id\", \"$1\", \"machine_name\", \".*/machines/(.*)\"\n  )\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Cluster - Ambient Temp Violations exceeds 40C for 96 hrs",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [
+              {
+                "column": "cluster_name",
+                "visible": true
+              },
+              {
+                "column": "machine_id",
+                "visible": false
+              },
+              {
+                "column": "value",
+                "visible": true
+              }
+            ],
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "avg by (cluster_name) (\n  (\n    # Get temperatures for machines in alert state\n    sum by (machine_id) (\n      min_over_time({\n        __name__=\"edgecontainer.googleapis.com/machine/ambient_temperature\",\n        monitored_resource=\"edgecontainer.googleapis.com/Machine\",\n        machine_id=~\"${machine_id.value}\"\n      }[96h])\n    ) > 40\n  )\n  * on (machine_id) group_left(cluster_name)\n  (\n    label_replace(\n      max by (cluster_name, machine_name) (\n        last_over_time({\n          __name__=\"edgecontainer.googleapis.com/node/current_node_version\",\n          monitored_resource=\"edgecontainer.googleapis.com/Node\",\n          cluster_name=~\"${cluster_name.value}\"\n        }[5m])\n      ),\n      \"machine_id\", \"$1\", \"machine_name\", \".*/machines/(.*)\"\n    )\n  )\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Cluster - Ambient Temp Violations",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [
+              {
+                "column": "cluster_name",
+                "visible": true
+              },
+              {
+                "column": "machine_id",
+                "visible": false
+              },
+              {
+                "column": "value",
+                "visible": true
+              }
+            ],
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": true,
+                  "prometheusQuery": "avg by (cluster_name) (\n  (\n    # Get temperatures for machines in alert state\n    sum by (machine_id) (\n      avg_over_time({\n        __name__=\"edgecontainer.googleapis.com/machine/ambient_temperature\",\n        monitored_resource=\"edgecontainer.googleapis.com/Machine\",\n        machine_id=~\"${machine_id.value}\"\n      }[${__interval}])\n    ) > 40\n    or \n    sum by (machine_id) (\n      avg_over_time({\n        __name__=\"edgecontainer.googleapis.com/machine/ambient_temperature\",\n        monitored_resource=\"edgecontainer.googleapis.com/Machine\",\n        machine_id=~\"${machine_id.value}\"\n      }[${__interval}])\n    ) < 10\n  )\n  * on (machine_id) group_left(cluster_name)\n  (\n    label_replace(\n      max by (cluster_name, machine_name) (\n        last_over_time({\n          __name__=\"edgecontainer.googleapis.com/node/current_node_version\",\n          monitored_resource=\"edgecontainer.googleapis.com/Node\",\n          cluster_name=~\"${cluster_name.value}\"\n        }[5m])\n      ),\n      \"machine_id\", \"$1\", \"machine_name\", \".*/machines/(.*)\"\n    )\n  )\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "height": 8,
+        "width": 14,
+        "widget": {
+          "title": "Populate Machine List Helper - Do Not Remove",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [],
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "600s",
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "600s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "resource.label.\"machine_id\""
+                      ],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"edgecontainer.googleapis.com/machine/power_consumption\" resource.type=\"edgecontainer.googleapis.com/Machine\" ${machine_id} ${project_id}"
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "yPos": 32,
+        "xPos": 14,
+        "height": 8,
+        "width": 14,
+        "widget": {
+          "title": "Populate Cluster List Helper - Do Not Remove",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [],
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "600s",
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "600s",
+                      "crossSeriesReducer": "REDUCE_SUM",
+                      "groupByFields": [
+                        "resource.label.\"cluster_name\""
+                      ],
+                      "perSeriesAligner": "ALIGN_MEAN"
+                    },
+                    "filter": "metric.type=\"edgecontainer.googleapis.com/node/current_node_version\" resource.type=\"edgecontainer.googleapis.com/Node\" ${cluster_name} ${project_id}"
+                  },
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/dashboards/gdc-node-view.json
+++ b/dashboards/gdc-node-view.json
@@ -1,130 +1,158 @@
 {
+  "displayName": "GDC - Node View",
   "dashboardFilters": [
     {
+      "comparator": "COMPARATOR_UNSPECIFIED",
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "cluster_name",
+      "stringValue": "None",
+      "templateVariable": "cluster_name",
+      "valueType": "STRING"
+    },
+    {
+      "comparator": "COMPARATOR_UNSPECIFIED",
       "filterType": "RESOURCE_LABEL",
       "labelKey": "project_id",
       "stringValue": "",
-      "templateVariable": "project_id"
-    },
-    {
-      "filterType": "RESOURCE_LABEL",
-      "labelKey": "cluster_name",
-      "stringValue": "",
-      "templateVariable": "cluster_name"
+      "templateVariable": "project_id",
+      "valueType": "STRING"
     }
   ],
-  "displayName": "GDC - Node View",
+  "description": "",
   "labels": {},
   "mosaicLayout": {
     "columns": 48,
     "tiles": [
       {
         "height": 8,
-        "widget": {
-          "scorecard": {
-            "blankView": {},
-            "thresholds": [],
-            "timeSeriesQuery": {
-              "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/cpu/total_cores'\n| ${project_id}\n| ${cluster_name}\n| group_by 10m, [value_total_cores_mean: mean(value.total_cores)]\n| every 10m\n| group_by [], [row_count: row_count()]",
-              "unitOverride": ""
-            }
-          },
-          "title": "Total Nodes"
-        },
-        "width": 8
-      },
-      {
-        "height": 8,
-        "widget": {
-          "scorecard": {
-            "blankView": {},
-            "thresholds": [],
-            "timeSeriesQuery": {
-              "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/cpu/total_cores'\n| ${project_id}\n| ${cluster_name}\n| group_by 1m, [value_total_cores_mean: mean(value.total_cores)]\n| every 1m\n| group_by [],\n    [value_total_cores_mean_aggregate: aggregate(value_total_cores_mean)]",
-              "unitOverride": ""
-            }
-          },
-          "title": "Total Cores"
-        },
         "width": 8,
-        "xPos": 8
-      },
-      {
-        "height": 8,
         "widget": {
+          "title": "Total Nodes",
+          "id": "",
           "scorecard": {
             "blankView": {},
+            "breakdowns": [],
+            "dimensions": [],
+            "measures": [],
             "thresholds": [],
             "timeSeriesQuery": {
-              "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/cpu/allocatable_cores'\n| ${project_id}\n| ${cluster_name}\n| group_by 1m, [value_allocatable_cores_mean: mean(value.allocatable_cores)]\n| every 1m\n| group_by [],\n    [value_allocatable_cores_mean_aggregate:\n       aggregate(value_allocatable_cores_mean)]",
+              "outputFullDuration": false,
+              "prometheusQuery": "count(\n  count by (node_name) (\n    avg_over_time({\n      __name__=\"kubernetes.io/anthos/node/cpu/total_cores\",\n      monitored_resource=\"k8s_node\",\n      cluster_name=~\"${cluster_name.value}\",\n      project_id=~\"${project_id.value}\"\n    }[10m])\n  )\n)",
               "unitOverride": ""
             }
-          },
-          "title": "Allocatable Cores"
-        },
-        "width": 8,
-        "xPos": 16
+          }
+        }
       },
       {
+        "xPos": 8,
         "height": 8,
+        "width": 8,
         "widget": {
+          "title": "Total Cores",
+          "id": "",
           "scorecard": {
             "blankView": {},
+            "breakdowns": [],
+            "dimensions": [],
+            "measures": [],
             "thresholds": [],
             "timeSeriesQuery": {
-              "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/memory/total_bytes'\n| ${project_id}\n| ${cluster_name}\n| group_by 1m, [value_total_bytes_mean: mean(value.total_bytes)]\n| every 1m\n| group_by [],\n    [value_total_bytes_mean_aggregate: aggregate(value_total_bytes_mean)]",
+              "outputFullDuration": false,
+              "prometheusQuery": "sum(\n  avg_over_time({\n    __name__=\"kubernetes.io/anthos/node/cpu/total_cores\",\n    monitored_resource=\"k8s_node\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\"\n  }[1m])\n)",
               "unitOverride": ""
             }
-          },
-          "title": "Total Memory"
-        },
-        "width": 8,
-        "xPos": 24
+          }
+        }
       },
       {
+        "xPos": 16,
         "height": 8,
+        "width": 8,
         "widget": {
+          "title": "Allocatable Cores",
+          "id": "",
           "scorecard": {
             "blankView": {},
+            "breakdowns": [],
+            "dimensions": [],
+            "measures": [],
             "thresholds": [],
             "timeSeriesQuery": {
-              "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/memory/allocatable_bytes'\n| ${project_id}\n| ${cluster_name}\n| group_by 1m, [value_allocatable_bytes_mean: mean(value.allocatable_bytes)]\n| every 1m\n| group_by [],\n    [value_allocatable_bytes_mean_aggregate:\n       aggregate(value_allocatable_bytes_mean)]",
+              "outputFullDuration": false,
+              "prometheusQuery": "sum(\n  avg_over_time({\n    __name__=\"kubernetes.io/anthos/node/cpu/allocatable_cores\",\n    monitored_resource=\"k8s_node\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\"\n  }[1m])\n)",
               "unitOverride": ""
             }
-          },
-          "title": "Allocatable Memory"
-        },
+          }
+        }
+      },
+      {
+        "xPos": 24,
+        "height": 8,
         "width": 8,
-        "xPos": 32
-      },
-      {
-        "height": 32,
         "widget": {
-          "collapsibleGroup": {
-            "collapsed": false
-          },
-          "title": "CPU and Memory"
-        },
-        "width": 48,
-        "yPos": 8
+          "title": "Total Memory (GB)",
+          "id": "",
+          "scorecard": {
+            "blankView": {},
+            "breakdowns": [],
+            "dimensions": [],
+            "measures": [],
+            "thresholds": [],
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "prometheusQuery": "sum(\n  avg_over_time({\n    __name__=\"kubernetes.io/anthos/node/memory/total_bytes\",\n    monitored_resource=\"k8s_node\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\"\n  }[1m])\n) / 1073741824",
+              "unitOverride": ""
+            }
+          }
+        }
       },
       {
+        "xPos": 32,
+        "height": 8,
+        "width": 8,
+        "widget": {
+          "title": "Allocatable Memory (GB)",
+          "id": "",
+          "scorecard": {
+            "blankView": {},
+            "breakdowns": [],
+            "dimensions": [],
+            "measures": [],
+            "thresholds": [],
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "prometheusQuery": "sum(\n  avg_over_time({\n    __name__=\"kubernetes.io/anthos/node/memory/allocatable_bytes\",\n    monitored_resource=\"k8s_node\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\"\n  }[1m])\n) / 1073741824",
+              "unitOverride": ""
+            }
+          }
+        }
+      },
+      {
+        "yPos": 8,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "CPU Usage per Node",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
+                "minAlignmentPeriod": "60s",
                 "plotType": "STACKED_AREA",
+                "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "{ fetch k8s_node\n  | metric 'kubernetes.io/anthos/node/cpu/allocatable_utilization'\n| ${project_id}\n| ${cluster_name}\n  | group_by 1m,\n      [value_allocatable_utilization_mean: mean(value.allocatable_utilization)]\n  | every 1m\n; fetch k8s_node\n  | metric 'kubernetes.io/anthos/node/cpu/allocatable_cores'\n| ${project_id}\n| ${cluster_name}\n  | group_by 1m, [value_allocatable_core_mean: mean(value.allocatable_cores)]\n  | every 1m }\n| join\n| value [scaled_util: val(0) * val(1)]\n",
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (node_name) (\n  avg_over_time({\n    __name__=\"kubernetes.io/anthos/node/cpu/allocatable_utilization\",\n    monitored_resource=\"k8s_node\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\"\n  }[1m])\n)\n*\nsum by (node_name) (\n  avg_over_time({\n    __name__=\"kubernetes.io/anthos/node/cpu/allocatable_cores\",\n    monitored_resource=\"k8s_node\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\"\n  }[1m])\n)",
                   "unitOverride": ""
                 }
               }
@@ -135,27 +163,47 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "yPos": 8
+        }
       },
       {
-        "height": 16,
+        "yPos": 8,
+        "height": 32,
+        "width": 48,
         "widget": {
-          "title": "Memory Usage per Node",
+          "title": "CPU and Memory",
+          "collapsibleGroup": {
+            "collapsed": false
+          },
+          "id": ""
+        }
+      },
+      {
+        "yPos": 8,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Memory Usage per Node (GB)",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
+                "minAlignmentPeriod": "60s",
                 "plotType": "STACKED_AREA",
+                "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "       fetch k8s_node\n| metric 'kubernetes.io/anthos/node/memory/used_bytes'\n| ${project_id}\n| ${cluster_name}\n| group_by 1m,\n    [value_used_bytes_mean: mean(value.used_bytes)]\n| every 1m\n| group_by [resource.node_name],\n    [value_used_bytes_mean_aggregate:\n       aggregate(value_used_bytes_mean)]",
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (node_name) (\n  avg_over_time({\n    __name__=\"kubernetes.io/anthos/node/memory/used_bytes\",\n    monitored_resource=\"k8s_node\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\"\n  }[1m])\n) / 1073741824",
                   "unitOverride": ""
                 }
               }
@@ -166,28 +214,34 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "xPos": 24,
-        "yPos": 8
+        }
       },
       {
+        "yPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "CPU Util % per Node",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
+                "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/cpu/allocatable_utilization'\n| ${project_id}\n| ${cluster_name}\n| group_by 1m,    [value_allocatable_utilization_mean: mean(value.allocatable_utilization)]\n| every 1m\n| scale '%'",
+                  "outputFullDuration": false,
+                  "prometheusQuery": "avg_over_time({\n  __name__=\"kubernetes.io/anthos/node/cpu/allocatable_utilization\",\n  monitored_resource=\"k8s_node\",\n  cluster_name=~\"${cluster_name.value}\",\n  project_id=~\"${project_id.value}\"\n}[1m]) * 100",
                   "unitOverride": ""
                 }
               }
@@ -198,27 +252,35 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "yPos": 24
+        }
       },
       {
+        "yPos": 24,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Memory Util % per Node",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
+                "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/memory/allocatable_utilization'\n| ${project_id}\n| ${cluster_name}\n| group_by 1m,\n    [value_allocatable_utilization_mean: mean(value.allocatable_utilization)]\n| every 1m\n| group_by [resource.node_name],\n    [value_allocatable_utilization_mean_aggregate:\n       aggregate(value_allocatable_utilization_mean)]\n| scale '%'",
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (node_name) (\n  avg_over_time({\n    __name__=\"kubernetes.io/anthos/node/memory/allocatable_utilization\",\n    monitored_resource=\"k8s_node\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\"\n  }[1m])\n) * 100",
                   "unitOverride": ""
                 }
               }
@@ -229,99 +291,34 @@
               "scale": "LINEAR"
             }
           }
-        },
+        }
+      },
+      {
+        "yPos": 40,
+        "height": 16,
         "width": 24,
-        "xPos": 24,
-        "yPos": 24
-      },
-      {
-        "height": 16,
-        "widget": {
-          "collapsibleGroup": {
-            "collapsed": false
-          },
-          "title": "Pod and Container Count"
-        },
-        "width": 48,
-        "yPos": 56
-      },
-      {
-        "height": 16,
-        "widget": {
-          "timeSeriesTable": {
-            "columnSettings": [
-              {
-                "column": "value",
-                "visible": false
-              }
-            ],
-            "dataSets": [
-              {
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/container/cpu/core_usage_time'\n| ${project_id}\n| ${cluster_name}\n| align rate(1m)\n| every 1m\n| group_by\n    [resource.project_id, resource.location, resource.cluster_name,\n     resource.namespace_name, resource.pod_name, resource.container_name,\n     metadata.system.node_name],\n    [value_core_usage_time_mean: pick_any(value.core_usage_time)]\n| group_by [metadata.system.node_name], [row_count()]"
-                }
-              }
-            ],
-            "metricVisualization": "NUMBER"
-          },
-          "title": "Number of Containers per Node"
-        },
-        "width": 24,
-        "xPos": 24,
-        "yPos": 56
-      },
-      {
-        "height": 16,
-        "widget": {
-          "timeSeriesTable": {
-            "columnSettings": [
-              {
-                "column": "value",
-                "visible": false
-              }
-            ],
-            "dataSets": [
-              {
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_pod\n| metric 'kubernetes.io/anthos/pod/network/received_bytes_count'\n| ${project_id}\n| ${cluster_name}\n| align rate(1m)\n| every 1m\n| group_by [resource.project_id, resource.location, resource.cluster_name, resource.namespace_name, resource.pod_name, metadata.system.node_name],\n    [value_received_bytes_count_mean: pick_any(value.received_bytes_count)]\n    | group_by [metadata.system.node_name], [row_count()]\n"
-                }
-              }
-            ],
-            "metricVisualization": "NUMBER"
-          },
-          "title": "Number of Pods per Node"
-        },
-        "width": 24,
-        "yPos": 56
-      },
-      {
-        "height": 16,
-        "widget": {
-          "collapsibleGroup": {
-            "collapsed": false
-          },
-          "title": "Network Usage per Node"
-        },
-        "width": 48,
-        "yPos": 40
-      },
-      {
-        "height": 16,
         "widget": {
           "title": "Received bytes per node",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
+                "minAlignmentPeriod": "60s",
                 "plotType": "STACKED_AREA",
+                "sort": [],
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/network/received_bytes_count'\n| ${project_id}\n| ${cluster_name}\n| filter (metric.interface =~ 'enp81s0f.*')\n| align rate(1m)\n| every 1m\n| group_by [resource.node_name],\n    [value_received_bytes_count_aggregate:\n       aggregate(value.received_bytes_count)]",
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (node_name) (\n  rate({\n    __name__=\"kubernetes.io/anthos/node/network/received_bytes_count\",\n    monitored_resource=\"k8s_node\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\",\n    interface=~\"enp81s0f.*\"\n  }[1m])\n)",
                   "unitOverride": ""
                 }
               }
@@ -332,76 +329,177 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "yPos": 40
+        }
       },
       {
+        "yPos": 40,
         "height": 16,
+        "width": 48,
         "widget": {
-          "title": "Send bytes per node",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
-            "dataSets": [
-              {
-                "breakdowns": [],
-                "dimensions": [],
-                "measures": [],
-                "plotType": "STACKED_AREA",
-                "targetAxis": "Y1",
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_node\n| metric 'kubernetes.io/anthos/node/network/sent_bytes_count'\n| ${project_id}\n| ${cluster_name}\n| filter (metric.interface =~ 'enp81s0f.*')\n| align rate(1m)\n| every 1m\n| group_by [resource.node_name],\n    [value_sent_bytes_count_aggregate:\n       aggregate(value.sent_bytes_count)]",
-                  "unitOverride": ""
-                }
-              }
-            ],
-            "thresholds": [],
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
-          }
-        },
-        "width": 24,
-        "xPos": 24,
-        "yPos": 40
-      },
-      {
-        "height": 16,
-        "widget": {
+          "title": "Network Usage per Node",
           "collapsibleGroup": {
             "collapsed": false
           },
-          "title": "Storage Usage per Node"
-        },
-        "width": 48,
-        "yPos": 72
+          "id": ""
+        }
       },
       {
+        "yPos": 40,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
-          "title": "Free Robin Disk Space % per Node",
+          "title": "Send bytes per node",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
+                "plotType": "STACKED_AREA",
+                "sort": [],
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "sum by (node_name) (\n  rate({\n    __name__=\"kubernetes.io/anthos/node/network/sent_bytes_count\",\n    monitored_resource=\"k8s_node\",\n    cluster_name=~\"${cluster_name.value}\",\n    project_id=~\"${project_id.value}\",\n    interface=~\"enp81s0f.*\"\n  }[1m])\n)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "thresholds": [],
+            "yAxis": {
+              "label": "",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 56,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Number of Pods per Cluster",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [
+              {
+                "column": "value",
+                "visible": true
+              },
+              {
+                "column": "cluster",
+                "visible": true
+              }
+            ],
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "count(\n  max by (cluster, node, pod) (\n    rate({\n      __name__=\"kubernetes.io/anthos/container_network_receive_bytes_total/counter\",\n      cluster=~\"${cluster_name.value}\",\n      project_id=~\"${project_id.value}\"\n    }[${__interval}])\n  )\n) by (cluster, node)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "yPos": 56,
+        "height": 16,
+        "width": 48,
+        "widget": {
+          "title": "Pod and Container Count",
+          "collapsibleGroup": {
+            "collapsed": false
+          },
+          "id": ""
+        }
+      },
+      {
+        "yPos": 56,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Number of Containers per Cluster",
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [
+              {
+                "column": "value",
+                "visible": true
+              },
+              {
+                "column": "cluster",
+                "visible": true
+              }
+            ],
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "tableTemplate": "",
+                "timeSeriesQuery": {
+                  "outputFullDuration": false,
+                  "prometheusQuery": "count(\n  max by (cluster, node, pod, container) (\n    rate({\n      __name__=\"kubernetes.io/anthos/container_network_receive_bytes_total/counter\",\n      cluster=~\"${cluster_name.value}\",\n      project_id=~\"${project_id.value}\"\n    }[${__interval}])\n  )\n) by (cluster, node)",
+                  "unitOverride": ""
+                }
+              }
+            ],
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "yPos": 72,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Free Robin Disk Space % per Node",
+          "id": "",
+          "xyChart": {
+            "chartOptions": {
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
+            },
+            "dataSets": [
+              {
+                "breakdowns": [],
+                "dimensions": [],
+                "legendTemplate": "",
+                "measures": [],
+                "minAlignmentPeriod": "60s",
                 "plotType": "LINE",
+                "sort": [],
                 "targetAxis": "Y2",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "{fetch k8s_container\n| metric 'external.googleapis.com/prometheus/robin_disk_nslices'\n| ${project_id}\n| ${cluster_name}\n| group_by [node_name],   [value_robin_disk_rawused_sum: mul(sum(value.robin_disk_nslices), 1073741824)]\n| every 1m\n;\nfetch k8s_container\n| metric 'external.googleapis.com/prometheus/robin_disk_size'\n| ${project_id}\n| ${cluster_name}\n| group_by [node_name],   [value_robin_disk_size_mean: sum(value.robin_disk_size)]\n| every 1m\n}\n| join\n| value [v_0: 1 - div(t_0.value_robin_disk_rawused_sum, t_1.value_robin_disk_size_mean)]",
+                  "outputFullDuration": false,
+                  "prometheusQuery": "(1 - (\n  sum by (node_name) (\n    avg_over_time({\n      __name__=\"external.googleapis.com/prometheus/robin_disk_nslices\",\n      monitored_resource=\"k8s_container\",\n      cluster_name=~\"${cluster_name.value}\",\n      project_id=~\"${project_id.value}\"\n    }[1m])\n  ) * 1073741824\n  /\n  sum by (node_name) (\n    avg_over_time({\n      __name__=\"external.googleapis.com/prometheus/robin_disk_size\",\n      monitored_resource=\"k8s_container\",\n      cluster_name=~\"${cluster_name.value}\",\n      project_id=~\"${project_id.value}\"\n    }[1m])\n  )\n) )*100",
                   "unitOverride": ""
                 }
               }
             ],
             "thresholds": [
               {
+                "color": "COLOR_UNSPECIFIED",
+                "direction": "DIRECTION_UNSPECIFIED",
                 "label": "",
                 "targetAxis": "Y2",
-                "value": 0.2
+                "value": 20
               }
             ],
             "y2Axis": {
@@ -409,35 +507,90 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "yPos": 72
+        }
       },
       {
+        "yPos": 72,
         "height": 16,
+        "width": 48,
         "widget": {
-          "title": "Free Robin Disk Space % per Node",
+          "title": "Storage Usage per Node",
+          "collapsibleGroup": {
+            "collapsed": false
+          },
+          "id": ""
+        }
+      },
+      {
+        "yPos": 72,
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Free Robin Disk Space per Node (GB)",
+          "id": "",
           "timeSeriesTable": {
+            "columnSettings": [],
             "dataSets": [
               {
+                "minAlignmentPeriod": "60s",
+                "tableTemplate": "",
                 "timeSeriesQuery": {
-                  "outputFullDuration": true,
-                  "timeSeriesQueryLanguage": "{fetch k8s_container\n| metric 'external.googleapis.com/prometheus/robin_disk_nslices'\n| ${project_id}\n| ${cluster_name}\n| group_by [Node: node_name],   [value_robin_disk_rawused_sum: mul(sum(value.robin_disk_nslices), 1073741824)]\n| every 1m\n;\nfetch k8s_container\n| metric 'external.googleapis.com/prometheus/robin_disk_size'\n| ${project_id}\n| ${cluster_name}\n| group_by [Node: node_name],   [value_robin_disk_size_mean: mean(value.robin_disk_size)]\n| every 1m\n}\n| join\n| value [Disk_Free: cast_units(t_1.value_robin_disk_size_mean - t_0.value_robin_disk_rawused_sum, 'By')]"
+                  "outputFullDuration": false,
+                  "prometheusQuery": "(\n  sum by (node_name) (\n    avg_over_time({\n      __name__=\"external.googleapis.com/prometheus/robin_disk_size\",\n      monitored_resource=\"k8s_container\",\n      cluster_name=~\"${cluster_name.value}\",\n      project_id=~\"${project_id.value}\"\n    }[1m])\n  )\n  -\n  sum by (node_name) (\n    avg_over_time({\n      __name__=\"external.googleapis.com/prometheus/robin_disk_nslices\",\n      monitored_resource=\"k8s_container\",\n      cluster_name=~\"${cluster_name.value}\",\n      project_id=~\"${project_id.value}\"\n    }[1m])\n  ) * 1073741824\n) / 1073741824",
+                  "unitOverride": ""
                 }
               }
             ],
             "displayColumnType": false,
-            "metricVisualization": "NUMBER",
-            "opsAnalyticsSettings": {
-              "maxRows": "0",
-              "pageSize": "0",
-              "showFilterBar": false
+            "metricVisualization": "NUMBER"
+          }
+        }
+      },
+      {
+        "yPos": 88,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Incidents",
+          "id": "",
+          "incidentList": {
+            "groupBy": "GROUP_BY_TYPE_UNSPECIFIED",
+            "monitoredResources": [],
+            "policyNames": [],
+            "userLabels": {}
+          }
+        }
+      },
+      {
+        "yPos": 88,
+        "xPos": 24,
+        "height": 8,
+        "width": 13,
+        "widget": {
+          "title": "Populate Cluster List - Do Not Remove",
+          "id": "",
+          "scorecard": {
+            "blankView": {},
+            "breakdowns": [],
+            "dimensions": [],
+            "measures": [],
+            "thresholds": [],
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "alignmentPeriod": "600s",
+                  "crossSeriesReducer": "REDUCE_COUNT",
+                  "groupByFields": [],
+                  "perSeriesAligner": "ALIGN_MEAN"
+                },
+                "filter": "metric.type=\"kubernetes.io/anthos/node/cpu/total_cores\" resource.type=\"k8s_node\" ${cluster_name} ${project_id}"
+              },
+              "unitOverride": ""
             }
           }
-        },
-        "width": 24,
-        "xPos": 24,
-        "yPos": 72
+        }
       }
     ]
   }

--- a/dashboards/gdc-vm-view.json
+++ b/dashboards/gdc-vm-view.json
@@ -1,59 +1,128 @@
 {
-  "dashboardFilters": [],
-  "displayName": "GDC - VM status",
+  "displayName": "GDC - VM Status",
+  "dashboardFilters": [
+    {
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "cluster_name",
+      "stringValue": "None",
+      "templateVariable": "cluster_name",
+      "valueType": "STRING"
+    },
+    {
+      "filterType": "METRIC_LABEL",
+      "labelKey": "namespace",
+      "stringValue": "vm-workloads",
+      "templateVariable": "namespace",
+      "valueType": "STRING"
+    },
+    {
+      "filterType": "RESOURCE_LABEL",
+      "labelKey": "project_id",
+      "stringValue": "",
+      "templateVariable": "project_id",
+      "valueType": "STRING"
+    }
+  ],
+  "description": "",
   "labels": {},
   "mosaicLayout": {
     "columns": 48,
     "tiles": [
       {
         "height": 16,
+        "width": 12,
+        "widget": {
+          "title": "VMs",
+          "id": "",
+          "scorecard": {
+            "breakdowns": [],
+            "dimensions": [],
+            "measures": [],
+            "sparkChartView": {
+              "sparkChartType": "SPARK_LINE"
+            },
+            "thresholds": [],
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "prometheusQuery": "count(\n  count by (kubernetes_vmi_label_kubevirt_vm) (\n    {\n      __name__=\"kubernetes.io/anthos/kubevirt_vmi_vcpu_seconds\",\n      monitored_resource=\"k8s_container\",\n      cluster_name=~\"${cluster_name.value}\",\n      namespace=~\"${namespace.value}\",\n      project_id=~\"${project_id.value}\"\n    }\n  )\n)",
+              "unitOverride": ""
+            }
+          }
+        }
+      },
+      {
+        "xPos": 12,
+        "height": 16,
+        "width": 12,
         "widget": {
           "title": "VM States",
-          "xyChart": {
-            "chartOptions": {
-              "mode": "COLOR"
-            },
+          "id": "",
+          "timeSeriesTable": {
+            "columnSettings": [
+              {
+                "column": "metric.label.\"kubernetes_vmi_label_kubevirt_vm\"",
+                "visible": true
+              },
+              {
+                "column": "metric.label.\"state\"",
+                "visible": true
+              },
+              {
+                "column": "value",
+                "visible": false
+              }
+            ],
             "dataSets": [
               {
-                "breakdowns": [],
-                "dimensions": [],
-                "measures": [],
-                "plotType": "LINE",
-                "targetAxis": "Y1",
+                "minAlignmentPeriod": "120s",
+                "tableTemplate": "",
                 "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric kubernetes.io/anthos/kubevirt_info\n| group_by [metadata.user.c'vm.kubevirt.io/name', metadata.system.state]\n| {ident; group_by sliding(24h)}\n| outer_join 0\n| value val(0)",
+                  "outputFullDuration": false,
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "120s",
+                      "crossSeriesReducer": "REDUCE_MAX",
+                      "groupByFields": [
+                        "metric.label.\"kubernetes_vmi_label_kubevirt_vm\"",
+                        "metric.label.\"state\""
+                      ],
+                      "perSeriesAligner": "ALIGN_RATE"
+                    },
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_vcpu_seconds\" resource.type=\"k8s_container\" ${cluster_name} ${namespace} ${project_id}"
+                  },
                   "unitOverride": ""
                 }
               }
             ],
-            "thresholds": [],
-            "timeshiftDuration": "0s",
-            "yAxis": {
-              "label": "",
-              "scale": "LINEAR"
-            }
+            "displayColumnType": false,
+            "metricVisualization": "NUMBER"
           }
-        },
-        "width": 12,
-        "xPos": 12
+        }
       },
       {
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "CPU usage per VM",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
                 "minAlignmentPeriod": "120s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "120s",
@@ -66,8 +135,9 @@
                       ],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
-                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_vcpu_seconds\" resource.type=\"k8s_container\""
-                  }
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_vcpu_seconds\" resource.type=\"k8s_container\" ${cluster_name} ${namespace} ${project_id}"
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
@@ -78,27 +148,32 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "xPos": 24
+        }
       },
       {
+        "yPos": 16,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Network TX Bytes/s per VM per interface",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
                 "minAlignmentPeriod": "120s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "120s",
@@ -112,8 +187,9 @@
                       ],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
-                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_transmit_bytes_total\" resource.type=\"k8s_container\""
-                  }
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_transmit_bytes_total\" resource.type=\"k8s_container\" ${cluster_name} ${namespace} ${project_id}"
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
@@ -124,27 +200,33 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "yPos": 16
+        }
       },
       {
+        "yPos": 16,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Network RX Bytes/s per VM per interface",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
                 "minAlignmentPeriod": "120s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "120s",
@@ -158,8 +240,9 @@
                       ],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
-                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_receive_bytes_total\" resource.type=\"k8s_container\""
-                  }
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_receive_bytes_total\" resource.type=\"k8s_container\" ${cluster_name} ${namespace} ${project_id}"
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
@@ -170,28 +253,32 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "xPos": 24,
-        "yPos": 16
+        }
       },
       {
+        "yPos": 32,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Network TX Errors/s per VM per interface",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
                 "minAlignmentPeriod": "120s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "120s",
@@ -205,8 +292,9 @@
                       ],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
-                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_transmit_errors_total\" resource.type=\"k8s_container\""
-                  }
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_transmit_errors_total\" resource.type=\"k8s_container\" ${cluster_name} ${namespace} ${project_id}"
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
@@ -217,27 +305,33 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "yPos": 32
+        }
       },
       {
+        "yPos": 32,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Network RX Errors/s per VM per interface",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
                 "minAlignmentPeriod": "120s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "120s",
@@ -251,8 +345,9 @@
                       ],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
-                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_receive_errors_total\" resource.type=\"k8s_container\""
-                  }
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_receive_errors_total\" resource.type=\"k8s_container\" ${cluster_name} ${namespace} ${project_id}"
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
@@ -263,28 +358,32 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "xPos": 24,
-        "yPos": 32
+        }
       },
       {
+        "yPos": 48,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Network TX Packets/s per VM per interface",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
                 "minAlignmentPeriod": "120s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "120s",
@@ -298,8 +397,9 @@
                       ],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
-                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_transmit_packets_total\" resource.type=\"k8s_container\""
-                  }
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_transmit_packets_total\" resource.type=\"k8s_container\" ${cluster_name} ${namespace} ${project_id}"
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
@@ -310,27 +410,33 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "yPos": 48
+        }
       },
       {
+        "yPos": 48,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Network RX Packets/s per VM per interface",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
                 "minAlignmentPeriod": "120s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "120s",
@@ -344,8 +450,9 @@
                       ],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
-                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_receive_packets_total\" resource.type=\"k8s_container\""
-                  }
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_receive_packets_total\" resource.type=\"k8s_container\" ${cluster_name} ${namespace} ${project_id}"
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
@@ -356,28 +463,32 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "xPos": 24,
-        "yPos": 48
+        }
       },
       {
+        "yPos": 64,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Network TX Packets dropped/s per VM per interface",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
                 "minAlignmentPeriod": "120s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "120s",
@@ -391,8 +502,9 @@
                       ],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
-                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_transmit_packets_dropped_total\" resource.type=\"k8s_container\""
-                  }
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_transmit_packets_dropped_total\" resource.type=\"k8s_container\" ${cluster_name} ${namespace} ${project_id}"
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
@@ -403,27 +515,33 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "yPos": 64
+        }
       },
       {
+        "yPos": 64,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Network RX Packets dropped/s per VM per interface",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
                 "minAlignmentPeriod": "120s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "120s",
@@ -437,8 +555,9 @@
                       ],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
-                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_receive_packets_dropped_total\" resource.type=\"k8s_container\""
-                  }
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_network_receive_packets_dropped_total\" resource.type=\"k8s_container\" ${cluster_name} ${namespace} ${project_id}"
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
@@ -449,28 +568,32 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "xPos": 24,
-        "yPos": 64
+        }
       },
       {
+        "yPos": 80,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Storage write iops per VM per disk",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
                 "minAlignmentPeriod": "120s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "120s",
@@ -484,8 +607,9 @@
                       ],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
-                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_storage_iops_write_total\" resource.type=\"k8s_container\""
-                  }
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_storage_iops_write_total\" resource.type=\"k8s_container\" ${cluster_name} ${namespace} ${project_id}"
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
@@ -496,27 +620,33 @@
               "scale": "LINEAR"
             }
           }
-        },
-        "width": 24,
-        "yPos": 80
+        }
       },
       {
+        "yPos": 80,
+        "xPos": 24,
         "height": 16,
+        "width": 24,
         "widget": {
           "title": "Storage read iops per VM per disk",
+          "id": "",
           "xyChart": {
             "chartOptions": {
-              "mode": "COLOR"
+              "displayHorizontal": false,
+              "mode": "COLOR",
+              "showLegend": false
             },
             "dataSets": [
               {
                 "breakdowns": [],
                 "dimensions": [],
+                "legendTemplate": "",
                 "measures": [],
                 "minAlignmentPeriod": "120s",
                 "plotType": "LINE",
                 "targetAxis": "Y1",
                 "timeSeriesQuery": {
+                  "outputFullDuration": false,
                   "timeSeriesFilter": {
                     "aggregation": {
                       "alignmentPeriod": "120s",
@@ -530,8 +660,9 @@
                       ],
                       "perSeriesAligner": "ALIGN_RATE"
                     },
-                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_storage_iops_read_total\" resource.type=\"k8s_container\""
-                  }
+                    "filter": "metric.type=\"kubernetes.io/anthos/kubevirt_vmi_storage_iops_read_total\" resource.type=\"k8s_container\" ${cluster_name} ${namespace} ${project_id}"
+                  },
+                  "unitOverride": ""
                 }
               }
             ],
@@ -542,83 +673,22 @@
               "scale": "LINEAR"
             }
           }
-        },
+        }
+      },
+      {
+        "yPos": 96,
+        "height": 16,
         "width": 24,
-        "xPos": 24,
-        "yPos": 80
-      },
-      {
-        "height": 16,
         "widget": {
-          "timeSeriesTable": {
-            "columnSettings": [
-              {
-                "column": "vm_name",
-                "visible": true
-              },
-              {
-                "column": "state",
-                "visible": true
-              },
-              {
-                "column": "value",
-                "visible": false
-              }
-            ],
-            "dataSets": [
-              {
-                "timeSeriesQuery": {
-                  "timeSeriesQueryLanguage": "fetch k8s_container\n| metric 'kubernetes.io/anthos/kubevirt_info'\n| group_by [vm_name: metadata.user.c'kubevirt/vm', state: metadata.system_labels.state]"
-                }
-              }
-            ],
-            "metricVisualization": "NUMBER"
-          },
-          "title": "VMs"
-        },
-        "width": 12
-      },
-      {
-        "height": 16,
-        "widget": {
-          "logsPanel": {
-            "filter": "resource.type=\"k8s_container\"\nresource.labels.cluster_name=\"clus-lab-1\"\nresource.labels.namespace_name=\"vm-workloads\"",
-            "resourceNames": [
-            ]
-          },
-          "title": "Nebula VM Logs"
-        },
-        "width": 24,
-        "yPos": 96
-      },
-      {
-        "height": 16,
-        "widget": {
-          "logsPanel": {
-            "filter": "resource.type=\"k8s_container\"\nresource.labels.cluster_name=\"clus-lab-2\"\nresource.labels.namespace_name=\"vm-workloads\"",
-            "resourceNames": [
-             ]
-          },
-          "title": "Captain America VM Logs"
-        },
-        "width": 24,
-        "xPos": 24,
-        "yPos": 96
-      },
-      {
-        "height": 16,
-        "widget": {
+          "title": "Incidents",
+          "id": "",
           "incidentList": {
+            "groupBy": "GROUP_BY_TYPE_UNSPECIFIED",
             "monitoredResources": [],
-            "policyNames": [
-              "alertPolicies/8875308465663576159",
-              "alertPolicies/538578941852527739"
-            ]
-          },
-          "title": "Incidents"
-        },
-        "width": 24,
-        "yPos": 112
+            "policyNames": [],
+            "userLabels": {}
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
## Summary

Converted existing GDC observability dashboards from MQL/Builder to PromQL, added dashboard-level filtering (cluster_name, project_id, machine_id), fixed unit formatting, and added two new dashboards.

## New Dashboards
- **Cluster View** — cluster version tracking, fleet connectivity, node status, and upgrade monitoring
- **Environmental Monitoring** — low power server detection, machine restarts, ambient temperature violations

## Changes to Existing Dashboards

### Daily Report
- Converted all widgets from MQL/Builder to PromQL
- Converted Machine Connected to GCP widget to PromQL table with `cluster_name` correlation via `label_replace` join on `node/current_node_version`
- Added Connected/Disconnected status column using `label_replace`
- Added `machine_id` dashboard filter and Populate Machine List Helper widget

### Node View
- Converted all widgets from MQL/Builder to PromQL
- Added `cluster_name` and `project_id` dashboard filters
- Converted memory widgets to display in GB (bytes ÷ 1073741824) instead of raw bytes
- Fixed Free Robin Disk Space % widget to display percentage 

### VM View
- Converted all widgets from MQL/Builder to PromQL
- Added `cluster_name` and `project_id` dashboard filters