### PR TITLE
Added new configurable alert policies for GDC node and storage monitoring

### DIFF
--- a/terraform/node/node-down-single.tf
+++ b/terraform/node/node-down-single.tf
@@ -1,0 +1,60 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_monitoring_alert_policy" "node-down-single" {
+  display_name = "1 GDC Node Down for more than ${var.duration_display}"
+  combiner     = "OR"
+  severity     = "CRITICAL"
+
+  conditions {
+    display_name = "1 Node Missing for more than ${var.duration_display}"
+
+    condition_prometheus_query_language {
+      query = <<-EOL
+        (
+          sum by (cluster_name, node_name) (
+            last_over_time(kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource="k8s_node"}[${var.lookback_window}])
+            unless
+            kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource="k8s_node"}
+          )
+        )
+        and on (cluster_name)
+        (
+          count by (cluster_name) (
+            last_over_time(kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource="k8s_node"}[${var.lookback_window}])
+            unless
+            kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource="k8s_node"}
+          ) == 1
+        )
+      EOL
+
+      duration            = var.duration
+      evaluation_interval = var.evaluation_interval
+    }
+  }
+
+  documentation {
+    content   = <<-EOT
+      Critical: 1 Node Missing
+      1 node has lost contact to Google Cloud Platform for more than ${var.duration_display}.
+
+      Possible Causes:
+      * Node Failure: The node is physically down or powered off.
+      * Network Partition: The node cannot reach Google Cloud.
+      * Survivability Mode: If other nodes follow, the site may be entering disconnected mode.
+    EOT
+    mime_type = "text/markdown"
+    subject   = "1 GDC Node Down for more than ${var.duration_display} | Cluster: $${resource.label.cluster_name} | Node: $${resource.label.node_name}"
+  }
+}

--- a/terraform/node/node-vcpu-utilization-high.tf
+++ b/terraform/node/node-vcpu-utilization-high.tf
@@ -1,0 +1,50 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_monitoring_alert_policy" "node-cpu-utilization-high" {
+  display_name = "Node vCPU Utilization Exceeds ${var.vcpu_utilization_threshold_percent}% for ${var.duration_display}"
+  combiner     = "OR"
+  severity     = "WARNING"
+
+  conditions {
+    display_name = "Node vCPU Utilization Exceeds ${var.vcpu_utilization_threshold_percent}% for ${var.duration_display}"
+
+    condition_prometheus_query_language {
+      query = <<-EOL
+        (
+          100 *
+          sum by (location, cluster_name, node_name) (
+            rate(kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource="k8s_node"}[${var.rate_window}])
+          )
+          /
+          sum by (location, cluster_name, node_name) (
+            kubernetes_io:anthos_node_cpu_total_cores{monitored_resource="k8s_node"}
+          )
+        ) > ${var.vcpu_utilization_threshold_percent}
+      EOL
+
+      duration            = var.duration
+      evaluation_interval = var.evaluation_interval
+    }
+  }
+
+  documentation {
+    content   = <<-EOT
+      Warning: High vCPU Utilization Detected.
+      The vCPU usage has remained above ${var.vcpu_utilization_threshold_percent}% for ${var.duration_display}.
+    EOT
+    mime_type = "text/markdown"
+    subject   = "vCPU Utilization exceeds ${var.vcpu_utilization_threshold_percent}% for ${var.duration_display} | Node: $${metric.label.node_name} | Cluster: $${metric.label.cluster_name}"
+  }
+}

--- a/terraform/node/nodes-down-multiple.tf
+++ b/terraform/node/nodes-down-multiple.tf
@@ -1,0 +1,53 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_monitoring_alert_policy" "nodes-down-multiple" {
+  display_name = "GDC Nodes Down (${var.node_count_threshold}+ nodes for ${var.duration_display} or more)"
+  combiner     = "OR"
+  severity     = "WARNING"
+
+  conditions {
+    display_name = "${var.node_count_threshold}+ Nodes Missing for ${var.duration_display} or more"
+
+    condition_prometheus_query_language {
+      query = <<-EOL
+        count by (cluster_name) (
+          max_over_time(kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource="k8s_node"}[${var.lookback_window}])
+          unless
+          kubernetes_io:anthos_node_cpu_core_usage_time{monitored_resource="k8s_node"}
+        ) >= ${var.node_count_threshold}
+      EOL
+
+      duration            = var.duration
+      evaluation_interval = var.evaluation_interval
+    }
+  }
+
+  documentation {
+    content   = <<-EOT
+      Critical: Multiple Nodes Missing (Potential Disconnect)
+      ${var.node_count_threshold} or more Nodes have lost contact with Google Cloud Platform for more than ${var.duration_display}.
+
+      Possible Causes:
+      1. Survivability Mode: The entire cluster may have lost connection to Google Cloud. Workloads may still be running locally.
+      2. Major Outage: Multiple physical nodes have failed.
+
+      Action Required:
+      * Attempt to reach the cluster via local/out-of-band management.
+      * Verify if the site is in Survivability Mode or if this is a hard outage.
+    EOT
+    mime_type = "text/markdown"
+    subject   = "${var.node_count_threshold}+ Nodes Missing for ${var.duration_display} or more | Cluster: $${resource.label.cluster_name}"
+  }
+}

--- a/terraform/node/variables.tf
+++ b/terraform/node/variables.tf
@@ -1,0 +1,55 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "duration" {
+  description = "How long the condition must persist before alerting. Example: 3600s = 60 min, 1800s = 30 min."
+  type        = string
+  default     = "3600s"
+}
+
+variable "duration_display" {
+  description = "Human-readable duration for display names and documentation."
+  type        = string
+  default     = "60 min"
+}
+
+variable "evaluation_interval" {
+  description = "How often the condition is checked."
+  type        = string
+  default     = "60s"
+}
+
+variable "rate_window" {
+  description = "Window used to calculate vCPU usage rate."
+  type        = string
+  default     = "5m"
+}
+
+variable "lookback_window" {
+  description = "How far back to check for previously reporting nodes. Must be longer than duration."
+  type        = string
+  default     = "180m"
+}
+
+variable "node_count_threshold" {
+  description = "Minimum number of missing nodes to trigger the multi-node alert."
+  type        = number
+  default     = 2
+}
+
+variable "vcpu_utilization_threshold_percent" {
+  description = "vCPU utilization percentage threshold. Alert fires when usage exceeds this value."
+  type        = number
+  default     = 95
+}

--- a/terraform/storage/robin-read-latency.tf
+++ b/terraform/storage/robin-read-latency.tf
@@ -1,0 +1,60 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_monitoring_alert_policy" "robin-read-latency" {
+  display_name = "Robin Read Latency > ${var.read_latency_threshold_display} for ${var.duration_display}"
+  combiner     = "OR"
+  severity     = "WARNING"
+
+  conditions {
+    display_name = "Robin Read Latency > ${var.read_latency_threshold_display} for ${var.duration_display}"
+
+    condition_prometheus_query_language {
+      query = <<-EOL
+        (
+          avg by (cluster_name) (
+            increase({__name__="external.googleapis.com/prometheus/robin_rio_vol_total_read_usecs",
+                      monitored_resource="k8s_container"}[${var.rate_window}])
+            /
+            increase({__name__="external.googleapis.com/prometheus/robin_rio_vol_total_read_ios",
+                      monitored_resource="k8s_container"}[${var.rate_window}])
+          )
+          > ${var.read_latency_threshold_usecs}
+        )
+      EOL
+
+      duration            = var.duration
+      evaluation_interval = var.evaluation_interval
+    }
+  }
+
+  documentation {
+    content   = <<-EOT
+      Warning: High Robin Storage Read Latency
+      Storage I/O read latency has exceeded ${var.read_latency_threshold_display} for over ${var.duration_display}.
+
+      Possible Causes:
+      - Disk Bottleneck: High I/O wait times on the underlying physical drives.
+      - Heavy Workload: A specific pod or service is performing intensive disk operations.
+      - Storage Fabric Issues: Potential congestion in the Robin.io storage layer.
+
+      Action Required:
+      1. Identify the affected cluster: $${resource.labels.cluster_name}
+      2. Check the Robin.io dashboard to pinpoint the specific volume or disk.
+      3. Review node disk health via the GDC console.
+    EOT
+    mime_type = "text/markdown"
+    subject   = "Robin Read Latency > ${var.read_latency_threshold_display} for ${var.duration_display} | Cluster: $${metric.label.cluster_name}"
+  }
+}

--- a/terraform/storage/robin-storage-free-space.tf
+++ b/terraform/storage/robin-storage-free-space.tf
@@ -1,0 +1,65 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_monitoring_alert_policy" "robin-storage-free-space" {
+  display_name = "Robin Storage Free Space < ${var.free_space_threshold_percent}%"
+  combiner     = "OR"
+  severity     = "CRITICAL"
+
+  conditions {
+    display_name = "Robin Storage Free Space < ${var.free_space_threshold_percent}%"
+
+    condition_prometheus_query_language {
+      query = <<-EOL
+        (
+          100 *
+          (
+            1 -
+              (
+                sum by (cluster_name, node_name) (
+                  {__name__="external.googleapis.com/prometheus/robin_disk_nslices",
+                  monitored_resource="k8s_container"}
+                ) * 1073741824
+                /
+                sum by (cluster_name, node_name) (
+                  {__name__="external.googleapis.com/prometheus/robin_disk_size",
+                  monitored_resource="k8s_container"}
+                )
+              )
+          )
+        ) <= ${var.free_space_threshold_percent}
+      EOL
+
+      duration            = var.duration
+      evaluation_interval = var.evaluation_interval
+    }
+  }
+
+  documentation {
+    content   = <<-EOT
+      CRITICAL: Robin Storage Near Exhaustion
+      The Robin storage pool has less than ${var.free_space_threshold_percent}% free space remaining.
+
+      Impact:
+      Applications will soon be unable to write data, leading to crashes and data corruption.
+
+      Action Required:
+      1. Immediate: Identify and delete unnecessary snapshots or orphaned PVCs.
+      2. Cleanup: Check for log accumulation in /var/log or application-specific paths.
+      3. Expansion: Plan for adding physical storage capacity to the GDC node.
+    EOT
+    mime_type = "text/markdown"
+    subject   = "Robin Disk < ${var.free_space_threshold_percent}% | Node: $${metric.label.node_name} | Cluster: $${metric.label.cluster_name}"
+  }
+}

--- a/terraform/storage/robin-write-latency.tf
+++ b/terraform/storage/robin-write-latency.tf
@@ -1,0 +1,60 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_monitoring_alert_policy" "robin-write-latency" {
+  display_name = "Robin Write Latency > ${var.write_latency_threshold_display} for ${var.duration_display}"
+  combiner     = "OR"
+  severity     = "WARNING"
+
+  conditions {
+    display_name = "Robin Write Latency > ${var.write_latency_threshold_display} for ${var.duration_display}"
+
+    condition_prometheus_query_language {
+      query = <<-EOL
+        (
+          avg by (cluster_name) (
+            increase({__name__="external.googleapis.com/prometheus/robin_rio_vol_total_write_usecs",
+                      monitored_resource="k8s_container"}[${var.rate_window}])
+            /
+            increase({__name__="external.googleapis.com/prometheus/robin_rio_vol_total_write_ios",
+                      monitored_resource="k8s_container"}[${var.rate_window}])
+          )
+          > ${var.write_latency_threshold_usecs}
+        )
+      EOL
+
+      duration            = var.duration
+      evaluation_interval = var.evaluation_interval
+    }
+  }
+
+  documentation {
+    content   = <<-EOT
+      Warning: High Robin Write Storage Latency
+      Storage I/O write latency has exceeded ${var.write_latency_threshold_display} for over ${var.duration_display}.
+
+      Possible Causes:
+      - Disk Bottleneck: High I/O wait times on the underlying physical drives.
+      - Heavy Workload: A specific pod or service is performing intensive disk operations.
+      - Storage Fabric Issues: Potential congestion in the Robin.io storage layer or networking bandwidth.
+
+      Action Required:
+      1. Identify the affected cluster: $${resource.labels.cluster_name}
+      2. Check the Robin.io dashboard to pinpoint the specific volume or disk.
+      3. Review node disk health via the GDC console.
+    EOT
+    mime_type = "text/markdown"
+    subject   = "Robin Write Latency > ${var.write_latency_threshold_display} for ${var.duration_display} | Cluster: $${metric.label.cluster_name}"
+  }
+}

--- a/terraform/storage/variables.tf
+++ b/terraform/storage/variables.tf
@@ -1,0 +1,67 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "duration" {
+  description = "How long the condition must persist before alerting. Example: 3600s = 60 min, 1800s = 30 min."
+  type        = string
+  default     = "3600s"
+}
+
+variable "duration_display" {
+  description = "Human-readable duration for display names and documentation."
+  type        = string
+  default     = "60 min"
+}
+
+variable "evaluation_interval" {
+  description = "How often the condition is checked."
+  type        = string
+  default     = "60s"
+}
+
+variable "rate_window" {
+  description = "Window used to calculate latency rates."
+  type        = string
+  default     = "5m"
+}
+
+variable "read_latency_threshold_usecs" {
+  description = "Read latency threshold in microseconds. Example: 200000 = 200ms, 100000 = 100ms."
+  type        = number
+  default     = 200000
+}
+
+variable "read_latency_threshold_display" {
+  description = "Human-readable read latency threshold for display names and documentation."
+  type        = string
+  default     = "200ms"
+}
+
+variable "write_latency_threshold_usecs" {
+  description = "Write latency threshold in microseconds. Example: 400000 = 400ms, 200000 = 200ms."
+  type        = number
+  default     = 400000
+}
+
+variable "write_latency_threshold_display" {
+  description = "Human-readable write latency threshold for display names and documentation."
+  type        = string
+  default     = "400ms"
+}
+
+variable "free_space_threshold_percent" {
+  description = "Free space percentage threshold. Alert fires when free space drops below this value."
+  type        = number
+  default     = 5
+}


### PR DESCRIPTION
## Summary
Adds 6 new alert policies as Terraform files with configurable variables. Customers can adjust thresholds, durations, and intervals to match their environment as needed.

## Alerts Added

### Node (`terraform/node/`)
- **node-down-single.tf** — Detects when a single node stops reporting metrics entirely
- **nodes-down-multiple.tf** — Detects when multiple nodes stop reporting metrics entirely
- **node-vcpu-utilization-high.tf** — Detects when actual node vCPU utilization exceeds a configurable threshold

### Storage (`terraform/storage/`)
- **robin-write-latency.tf** — Detects when Robin storage write latency exceeds a configurable threshold
- **robin-read-latency.tf** — Detects when Robin storage read latency exceeds a configurable threshold
- **robin-storage-free-space.tf** — Detects when Robin disk free space drops below a configurable percentage

## Configurable Variables
All alert thresholds and timing values are defined as Terraform variables with defaults. Customers can override them per environment as needed.

| Variable | Default | Used By |
|---|---|---|
| `duration` | `3600s` | All created alerts |
| `duration_display` | `60 min` | All created alerts (display names/docs) |
| `evaluation_interval` | `60s` | All created alerts |
| `rate_window` | `5m` | vCPU utilization, read/write latency |
| `lookback_window` | `180m` | Node down alerts |
| `node_count_threshold` | `2` | Multiple nodes down |
| `vcpu_utilization_threshold_percent` | `95` | vCPU utilization |
| `read_latency_threshold_usecs` | `200000` | Read latency |
| `read_latency_threshold_display` | `200ms` | Read latency (display names/docs) |
| `write_latency_threshold_usecs` | `400000` | Write latency |
| `write_latency_threshold_display` | `400ms` | Write latency (display names/docs) |
| `free_space_threshold_percent` | `5` | Storage free space |

## Notes

**node-vcpu-utilization-high.tf** — There is a similar alert in the public repo called `node-cpu-usage-high.tf` which monitors allocatable CPU capacity (`allocatable / capacity`). This alert monitors actual CPU usage (`core_usage_time / total_cores`).

**nodes-down-multiple.tf / node-down-single.tf** — There are similar alerts in the public repo called `multiple-nodes-not-ready-realtime.tf` and `node-not-ready-30m.tf` which detect nodes that are still reporting but have a NotReady condition. These alerts detect nodes that have stopped reporting metrics entirely, using a `last_over_time(...) unless current_data` pattern.

## Validation
 **GCP UI**: All listed alerts have been verified in the `gdc-solutions-customer-sim` project.